### PR TITLE
chore!: move from @seliseblocks/blocks-kit to @seliseblocks/genesis-os

### DIFF
--- a/client/app/components/auth-page-shell/auth-page-shell.tsx
+++ b/client/app/components/auth-page-shell/auth-page-shell.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { Link } from "react-router";
 import { KeyRound, Lock, ShieldCheck } from "lucide-react";
 import { Logo } from "@/components/logo";
-import { ThemeSwitcher } from "@seliseblocks/blocks-kit";
+import { ThemeSwitcher } from "@seliseblocks/genesis-os";
 
 export interface AuthPageShellProps {
   badge: string;

--- a/client/app/components/breadcrumb/breadcrumb.test.tsx
+++ b/client/app/components/breadcrumb/breadcrumb.test.tsx
@@ -12,7 +12,7 @@ vi.mock("react-router", async (importOriginal) => {
   return { ...actual, useLocation: () => ({ pathname: h.pathname }) };
 });
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   usePathSegments: () => h.segments,
 }));
 

--- a/client/app/components/breadcrumb/breadcrumb.tsx
+++ b/client/app/components/breadcrumb/breadcrumb.tsx
@@ -8,7 +8,7 @@ import {
   BreadcrumbSeparator,
 } from "../ui-kits/breadcrumb/breadcrumb";
 import { Link, useLocation } from "react-router";
-import { usePathSegments } from "@seliseblocks/blocks-kit/hooks";
+import { usePathSegments } from "@seliseblocks/genesis-os/hooks";
 import { BREADCRUMB_CUSTOM_TITLES } from "@/constants/breadcrumb-custom-title";
 import { cn } from "@/lib/utils";
 

--- a/client/app/components/data-table-faceted-filter/data-table-faceted-filter.test.tsx
+++ b/client/app/components/data-table-faceted-filter/data-table-faceted-filter.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   usePopoverWidth: () => [{ current: null }, 200],
   useIsMobile: () => false,
 }));

--- a/client/app/components/data-table-faceted-filter/data-table-faceted-filter.tsx
+++ b/client/app/components/data-table-faceted-filter/data-table-faceted-filter.tsx
@@ -15,8 +15,8 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "../ui-kits/popover/popover";
 import { Separator } from "../ui-kits/separator/separator";
 import { Badge } from "../ui-kits/badge/badge";
-import { usePopoverWidth } from "@seliseblocks/blocks-kit/hooks";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { usePopoverWidth } from "@seliseblocks/genesis-os/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 interface DataTableFacetedFilterProps<TData, TValue> {
   column?: Column<TData, TValue>;
   title?: string;

--- a/client/app/components/date-range-filter/date-range-filter.test.tsx
+++ b/client/app/components/date-range-filter/date-range-filter.test.tsx
@@ -5,7 +5,7 @@ import type { DateRange } from "react-day-picker";
 
 const h = vi.hoisted(() => ({ onSelect: undefined as ((d: DateRange | undefined) => void) | undefined }));
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({ useIsMobile: () => false }));
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({ useIsMobile: () => false }));
 vi.mock("@/components/ui-kits/calendar/calendar", () => ({
   Calendar: ({ onSelect }: { onSelect: (d: DateRange | undefined) => void }) => {
     h.onSelect = onSelect;

--- a/client/app/components/date-range-filter/date-range-filter.tsx
+++ b/client/app/components/date-range-filter/date-range-filter.tsx
@@ -7,7 +7,7 @@ import { CalendarIcon } from "lucide-react";
 import { DateRange } from "react-day-picker";
 import { formatDate } from "@/lib/utils";
 import { Separator } from "../ui-kits/separator/separator";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 interface DateRangeFilterProps<TData, TValue> {
   column?: Column<TData, TValue>;
   title: string;

--- a/client/app/components/environment-card/environment-card.test.tsx
+++ b/client/app/components/environment-card/environment-card.test.tsx
@@ -12,10 +12,10 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ setSelectedProject: h.setSelectedProject }),
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useStartImpersonation: () => ({ mutateAsync: h.startImpersonation }),
 }));
 vi.mock("@/hooks/use-project", () => ({

--- a/client/app/components/environment-card/environment-card.tsx
+++ b/client/app/components/environment-card/environment-card.tsx
@@ -6,15 +6,15 @@ import { Dialog, DialogTrigger } from "@/components/ui-kits/dialog/dialog";
 import { ConfirmationModal } from "@/components/confirmation-modal/confirmation-modal";
 import { IProject } from "@/models/project.model";
 import { useGetProjectStatus, useRestoreProject } from "@/hooks/use-project";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
-import { useStartImpersonation } from "@seliseblocks/blocks-kit/hooks";
+import { useProjectStore } from "@seliseblocks/genesis-os";
+import { useStartImpersonation } from "@seliseblocks/genesis-os/hooks";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui-kits/tooltip/tooltip";
-import { isErrorWithErrors, showErrorToast, showSuccessToast } from "@seliseblocks/blocks-kit/utils";
+import { isErrorWithErrors, showErrorToast, showSuccessToast } from "@seliseblocks/genesis-os/utils";
 import { environmentOptions } from "@/constants/environment-options";
 type EnvironmentCardProps = {
   project: IProject;

--- a/client/app/components/environment-migration/environment-migration-wizard.test.tsx
+++ b/client/app/components/environment-migration/environment-migration-wizard.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => ({ resetFormData: vi.fn(), selectedTenantGroup: "grp-1" }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: (selector: (s: { selectedTenantGroup: string }) => unknown) =>
     selector({ selectedTenantGroup: h.selectedTenantGroup }),
 }));

--- a/client/app/components/environment-migration/environment-migration-wizard.tsx
+++ b/client/app/components/environment-migration/environment-migration-wizard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { X } from "lucide-react";
 import StepVerticalTrackBar from "@/components/stepper/vertical-track-bar";
 import StepHorizontalTrackBar from "@/components/stepper/horizontal-track-bar";

--- a/client/app/components/environment-migration/environment-service-selection-form.test.tsx
+++ b/client/app/components/environment-migration/environment-service-selection-form.test.tsx
@@ -8,7 +8,7 @@ const h = vi.hoisted(() => ({
   selectedTenantGroup: "group-1" as string | undefined,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => {
+vi.mock("@seliseblocks/genesis-os", () => {
   const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
   return {
     useProjectStore: () => ({ selectedTenantGroup: h.selectedTenantGroup }),

--- a/client/app/components/environment-migration/environment-service-selection-form.tsx
+++ b/client/app/components/environment-migration/environment-service-selection-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { AlertTriangle } from "lucide-react";
 import { useStepper } from "@/components/stepper/stepper-provider";
 import { useGetProjects } from "@/hooks/use-project";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { environmentOptions } from "@/components/create-project/form/create-project-environments-form/utils";
 import { Button } from "@/components/ui-kits/button/button";
 import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";

--- a/client/app/components/environment-migration/review-confirm-form.test.tsx
+++ b/client/app/components/environment-migration/review-confirm-form.test.tsx
@@ -16,7 +16,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit", () => {
+vi.mock("@seliseblocks/genesis-os", () => {
   const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
   return {
     useProjectStore: () => ({ selectedTenantGroup: h.selectedTenantGroup }),
@@ -26,7 +26,7 @@ vi.mock("@seliseblocks/blocks-kit", () => {
     TooltipProvider: Passthrough,
   };
 });
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useCountDown: () => ({ remainingTime: h.remainingTime, reset: h.reset }),
 }));
 vi.mock("@/hooks/use-project", () => ({

--- a/client/app/components/environment-migration/review-confirm-form.tsx
+++ b/client/app/components/environment-migration/review-confirm-form.tsx
@@ -27,10 +27,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui-kits/tooltip/tooltip";
-import { useCountDown } from "@seliseblocks/blocks-kit/hooks";
+import { useCountDown } from "@seliseblocks/genesis-os/hooks";
 import { useInitiateMigration, useVerifyMigration } from "@/hooks/use-project";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useDataMigrationFormState } from "./migration-form-state";
 import { MIGRATION_SERVICE_NAME_TO_ID, migrationVerificationSchema } from "./migration-form-schema";
 

--- a/client/app/components/filter-toolbar/date-range/date-range.tsx
+++ b/client/app/components/filter-toolbar/date-range/date-range.tsx
@@ -3,7 +3,7 @@ import { Calendar } from "@/components/ui-kits/calendar/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui-kits/popover/popover";
 import { CalendarIcon } from "lucide-react";
 import { formatDate } from "@/lib/utils";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 import { Separator } from "@/components/ui-kits/separator/separator";
 import { MouseEvent, useEffect, useState } from "react";
 type DateRangeType = { from?: Date; to?: Date } | null;

--- a/client/app/components/filter-toolbar/multi-select/multi-select.tsx
+++ b/client/app/components/filter-toolbar/multi-select/multi-select.tsx
@@ -1,7 +1,7 @@
 import { CheckIcon, PlusCircledIcon } from "@radix-ui/react-icons";
 import { cn } from "@/lib/utils";
-import { usePopoverWidth } from "@seliseblocks/blocks-kit/hooks";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { usePopoverWidth } from "@seliseblocks/genesis-os/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui-kits/popover/popover";
 import { Button } from "@/components/ui-kits/button/button";
 import { Separator } from "@/components/ui-kits/separator/separator";

--- a/client/app/components/filter-toolbar/radio/radio.tsx
+++ b/client/app/components/filter-toolbar/radio/radio.tsx
@@ -1,6 +1,6 @@
 import { PlusCircledIcon } from "@radix-ui/react-icons";
-import { usePopoverWidth } from "@seliseblocks/blocks-kit/hooks";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { usePopoverWidth } from "@seliseblocks/genesis-os/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui-kits/popover/popover";
 import { Button } from "@/components/ui-kits/button/button";
 import { Separator } from "@/components/ui-kits/separator/separator";

--- a/client/app/components/logo/index.tsx
+++ b/client/app/components/logo/index.tsx
@@ -5,7 +5,7 @@ interface LogoProps {
   height?: number;
   className?: string;
 }
-import { useTheme } from "@seliseblocks/blocks-kit/hooks";
+import { useTheme } from "@seliseblocks/genesis-os/hooks";
 export function Logo({ src, alt, width, height, className }: LogoProps) {
   const { resolvedTheme } = useTheme();
   if (src) {

--- a/client/app/components/project-card/project-card.test.tsx
+++ b/client/app/components/project-card/project-card.test.tsx
@@ -34,7 +34,7 @@ vi.mock("react-router", async (importOriginal) => {
   return { ...actual, useNavigate: () => h.navigate };
 });
 
-vi.mock("@seliseblocks/blocks-kit", async () => {
+vi.mock("@seliseblocks/genesis-os", async () => {
   const React = await import("react");
   const Pass = ({ children }: { children?: React.ReactNode }) =>
     React.createElement(React.Fragment, null, children);

--- a/client/app/components/project-card/project-card.tsx
+++ b/client/app/components/project-card/project-card.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui-kits/tooltip/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui-kits/popover/popover";
 import { environmentOptions } from "@/constants/environment-options";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { ChevronRight, Settings2 } from "lucide-react";
 import { IProject } from "@/models/project.model";
 

--- a/client/app/components/ui-kits/tooltip/tooltip.tsx
+++ b/client/app/components/ui-kits/tooltip/tooltip.tsx
@@ -1,1 +1,1 @@
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@seliseblocks/blocks-kit";
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@seliseblocks/genesis-os";

--- a/client/app/cross-modules/ai/components/aimodels/aimodel-card/aimodel-card.test.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/aimodel-card/aimodel-card.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const h = vi.hoisted(() => ({ navigate: vi.fn(), scoped: (p: string) => `/scoped/${p}` }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({ useScopedPath: () => h.scoped }));
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({ useScopedPath: () => h.scoped }));
 
 import { ProviderCard } from "./aimodel-card";
 

--- a/client/app/cross-modules/ai/components/aimodels/aimodel-card/aimodel-card.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/aimodel-card/aimodel-card.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui-kits/card/card";
 import { ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui-kits/button/button";

--- a/client/app/cross-modules/ai/components/aimodels/modals/aimodel-addkey-modal-custom/aimodel-addkey-modal-custom.test.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/modals/aimodel-addkey-modal-custom/aimodel-addkey-modal-custom.test.tsx
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => {
+vi.mock("@seliseblocks/genesis-os", () => {
   const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
   return {
     useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),

--- a/client/app/cross-modules/ai/components/aimodels/modals/aimodel-addkey-modal-custom/aimodel-addkey-modal-custom.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/modals/aimodel-addkey-modal-custom/aimodel-addkey-modal-custom.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/components/ui-kits/tooltip/tooltip";
 import { Info, Trash2 } from "lucide-react";
 import { transformToUniversal } from "@blocks-ai/utils/aimodel-form.utils";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useCreateModel } from "@blocks-ai/hooks/use-aimodel";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 const CustomAddKeyFormSchema = z.object({

--- a/client/app/cross-modules/ai/components/aimodels/modals/aimodel-addkey-modal/aimodel-addkey-modal.test.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/modals/aimodel-addkey-modal/aimodel-addkey-modal.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-ai/hooks/use-aimodel", () => ({

--- a/client/app/cross-modules/ai/components/aimodels/modals/aimodel-addkey-modal/aimodel-addkey-modal.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/modals/aimodel-addkey-modal/aimodel-addkey-modal.tsx
@@ -32,7 +32,7 @@ import { getProviderDisplayName, ServicePlatform } from "@blocks-ai/utils/aimode
 import { resolveModelConfig, transformToUniversal } from "@blocks-ai/utils/aimodel-form.utils";
 import { useCreateModel } from "@blocks-ai/hooks/use-aimodel";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 interface ModelAddKeyModalProps {
   provider: string;
   baseUrl: string;

--- a/client/app/cross-modules/ai/components/aimodels/modals/aimodel-deletemodel-modal/aimodel-deletemodel-modal.test.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/modals/aimodel-deletemodel-modal/aimodel-deletemodel-modal.test.tsx
@@ -7,7 +7,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-ai/hooks/use-aimodel", () => ({

--- a/client/app/cross-modules/ai/components/aimodels/modals/aimodel-deletemodel-modal/aimodel-deletemodel-modal.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/modals/aimodel-deletemodel-modal/aimodel-deletemodel-modal.tsx
@@ -2,7 +2,7 @@ import { ConfirmationModal } from "@/components/confirmation-modal/confirmation-
 import { Dialog } from "@/components/ui-kits/dialog/dialog";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { isErrorWithErrors } from "@/lib/error";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useDeleteModel } from "@blocks-ai/hooks/use-aimodel";
 type DeleteModelProps = {
   modelId: string;

--- a/client/app/cross-modules/ai/components/aimodels/modals/aimodel-editkey-modal-custom/aimodel-editkey-modal-custom.test.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/modals/aimodel-editkey-modal-custom/aimodel-editkey-modal-custom.test.tsx
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => {
+vi.mock("@seliseblocks/genesis-os", () => {
   const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
   return {
     useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),

--- a/client/app/cross-modules/ai/components/aimodels/modals/aimodel-editkey-modal-custom/aimodel-editkey-modal-custom.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/modals/aimodel-editkey-modal-custom/aimodel-editkey-modal-custom.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/components/ui-kits/tooltip/tooltip";
 import { Info, Trash2, Pen } from "lucide-react";
 import { IModelInfo, IUpdateModelPayload } from "@blocks-ai/types/aimodel.service.type";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useUpdateModel } from "@blocks-ai/hooks/use-aimodel";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 const CustomEditKeyFormSchema = z.object({

--- a/client/app/cross-modules/ai/components/aimodels/modals/aimodel-editkey-modal/aimodel-editkey-modal.test.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/modals/aimodel-editkey-modal/aimodel-editkey-modal.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-ai/hooks/use-aimodel", () => ({

--- a/client/app/cross-modules/ai/components/aimodels/modals/aimodel-editkey-modal/aimodel-editkey-modal.tsx
+++ b/client/app/cross-modules/ai/components/aimodels/modals/aimodel-editkey-modal/aimodel-editkey-modal.tsx
@@ -26,7 +26,7 @@ import { resolveModelConfig } from "@blocks-ai/utils/aimodel-form.utils";
 import { IModelInfo, IUpdateModelPayload } from "@blocks-ai/types/aimodel.service.type";
 import { useUpdateModel } from "@blocks-ai/hooks/use-aimodel";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 interface ModelEditKeyModalProps {
   modelOptions: { model: string; goodName: string }[];
   editKeyModalOpen: boolean;

--- a/client/app/cross-modules/ai/components/lmt-query-agent/lmt-query-agent.test.tsx
+++ b/client/app/cross-modules/ai/components/lmt-query-agent/lmt-query-agent.test.tsx
@@ -6,7 +6,7 @@ const h = vi.hoisted(() => ({
   streamQuery: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-ai/hooks/use-agent", () => ({

--- a/client/app/cross-modules/ai/components/lmt-query-agent/lmt-query-agent.tsx
+++ b/client/app/cross-modules/ai/components/lmt-query-agent/lmt-query-agent.tsx
@@ -2,7 +2,7 @@ import React, { Fragment, useCallback, useEffect, useRef, useState } from "react
 import { Bot, X } from "lucide-react";
 import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useLMTQueryAgentSSE } from "@blocks-ai/hooks/use-agent";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/client/app/cross-modules/ai/pages/ai-model-selected/aimodel-selected.test.tsx
+++ b/client/app/cross-modules/ai/pages/ai-model-selected/aimodel-selected.test.tsx
@@ -16,10 +16,10 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/app/proj/${p}`,
 }));
 vi.mock("@blocks-ai/hooks/use-aimodel", () => ({

--- a/client/app/cross-modules/ai/pages/ai-model-selected/aimodel-selected.tsx
+++ b/client/app/cross-modules/ai/pages/ai-model-selected/aimodel-selected.tsx
@@ -19,8 +19,8 @@ import {
   useSeedModelsByProvider,
   useSeedProviders,
 } from "@blocks-ai/hooks/use-aimodel";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useProjectStore } from "@seliseblocks/genesis-os";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { Pagination } from "@/components/ui-kits/pagination/pagination";
 import { Plus, ArrowLeft } from "lucide-react";
 const PROVIDER_PNG_MAP: Record<string, string> = {

--- a/client/app/cross-modules/communication/mail/components/email-service/basic-information/basic-information.test.tsx
+++ b/client/app/cross-modules/communication/mail/components/email-service/basic-information/basic-information.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@blocks-localization/hooks/use-language-manager", () => ({
 vi.mock("@blocks-communication/mail/hooks/use-email-template", () => ({
   useSaveMailTemplate: () => ({ isPending: h.isPending, mutateAsync: h.saveTemplate }),
 }));
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@/hooks/use-toast", () => ({

--- a/client/app/cross-modules/communication/mail/components/email-service/basic-information/basic-information.tsx
+++ b/client/app/cross-modules/communication/mail/components/email-service/basic-information/basic-information.tsx
@@ -23,7 +23,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useGetEmailConfigs } from "@blocks-communication/mail/hooks/use-email-config";
 import { useSaveMailTemplate } from "@blocks-communication/mail/hooks/use-email-template";
 import { useGetLanguages } from "@blocks-localization/hooks/use-language-manager";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import {
   Form,
   FormControl,

--- a/client/app/cross-modules/communication/mail/components/email-service/email-table-toolbar/email-table-toolbar.test.tsx
+++ b/client/app/cross-modules/communication/mail/components/email-service/email-table-toolbar/email-table-toolbar.test.tsx
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
   activeFilters: 0,
 }));
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({ useIsMobile: () => h.isMobile }));
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({ useIsMobile: () => h.isMobile }));
 vi.mock("@/hooks/use-active-filters-count", () => ({
   useActiveFiltersCount: () => h.activeFilters,
 }));

--- a/client/app/cross-modules/communication/mail/components/email-service/email-table-toolbar/email-table-toolbar.tsx
+++ b/client/app/cross-modules/communication/mail/components/email-service/email-table-toolbar/email-table-toolbar.tsx
@@ -4,7 +4,7 @@ import { Table } from "@tanstack/react-table";
 import { DateRange } from "react-day-picker";
 import { Cross2Icon } from "@radix-ui/react-icons";
 import { Button } from "@/components/ui-kits/button/button";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 import { useActiveFiltersCount } from "@/hooks/use-active-filters-count";
 import {
   Sheet,

--- a/client/app/cross-modules/communication/mail/components/messaging/messaging-table-toolbar/messaging-table-toolbar.tsx
+++ b/client/app/cross-modules/communication/mail/components/messaging/messaging-table-toolbar/messaging-table-toolbar.tsx
@@ -5,7 +5,7 @@ import { Filter } from "lucide-react";
 import { Button } from "@/components/ui-kits/button/button";
 import { configurations, protocols } from "@blocks-communication/mail/constants/messaging";
 import { DataTableFacetedFilter } from "@/components/data-table-faceted-filter/data-table-faceted-filter";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 import { useActiveFiltersCount } from "@/hooks/use-active-filters-count";
 import {
   Sheet,

--- a/client/app/cross-modules/communication/mail/email/email-communication-details/email-communication-details.test.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-communication-details/email-communication-details.test.tsx
@@ -35,14 +35,14 @@ vi.mock("@blocks-communication/mail/hooks/use-email-config", () => ({
     data: h.configs,
   }),
 }));
-vi.mock("@seliseblocks/blocks-kit/store", () => ({
+vi.mock("@seliseblocks/genesis-os/store", () => ({
   useUserStore: (selector: (state: { userDetails: { email: string } | null }) => unknown) =>
     selector({ userDetails: h.userDetails }),
 }));
 vi.mock("@blocks-localization/hooks/use-language-manager", () => ({
   useGetLanguages: () => ({ isLoading: false, data: { data: [] } }),
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/scoped/${p}`,
   usePathSegments: () => [],
 }));

--- a/client/app/cross-modules/communication/mail/email/email-communication-details/email-communication-details.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-communication-details/email-communication-details.tsx
@@ -11,8 +11,8 @@ import EditCommunication from "@blocks-communication/mail/components/email-servi
 import { checkValidDate, formatFullDate, parseDateString } from "@/lib/utils";
 import { toast } from "@/hooks/use-toast";
 import { useNavigate } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
-import { useUserStore } from "@seliseblocks/blocks-kit/store";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
+import { useUserStore } from "@seliseblocks/genesis-os/store";
 import { useGetEmailConfigs } from "@blocks-communication/mail/hooks/use-email-config";
 import { langConfigureData } from "@blocks-localization/constants/language-dummy-data";
 import {

--- a/client/app/cross-modules/communication/mail/email/email-service-table/email-service-table.test.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-service-table/email-service-table.test.tsx
@@ -16,7 +16,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({ useScopedPath: () => (p: string) => `/s/${p}` }));
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({ useScopedPath: () => (p: string) => `/s/${p}` }));
 vi.mock("nuqs", async () => {
   const React = await import("react");
   return {

--- a/client/app/cross-modules/communication/mail/email/email-service-table/email-service-table.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-service-table/email-service-table.tsx
@@ -21,7 +21,7 @@ import { useGetLanguages } from "@blocks-localization/hooks/use-language-manager
 import { CirclePlus } from "lucide-react";
 import { useNavigate } from "react-router";
 import { useMemo } from "react";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { useEmailUsageFilterQueryParams } from "../email-usage/email-usage-filter-toolbar";
 import { useQueryState } from "nuqs";
 import {

--- a/client/app/cross-modules/communication/mail/email/email-service-table/email-template-list.test.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-service-table/email-template-list.test.tsx
@@ -14,7 +14,7 @@ const h = vi.hoisted(() => ({
 vi.mock("react-router", () => ({
   useNavigate: () => h.navigate,
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/scoped/${p}`,
 }));
 vi.mock("@/hooks/use-toast", () => ({ toast: h.toast }));

--- a/client/app/cross-modules/communication/mail/email/email-service-table/email-template-list.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-service-table/email-template-list.tsx
@@ -29,7 +29,7 @@ import {
   useDeleteEmailTemplate,
 } from "@blocks-communication/mail/hooks/use-email-template";
 import { useNavigate } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 type EmailTemplateListProps = {
   templates: IEmailTemplate[];
   isLoading: boolean;

--- a/client/app/cross-modules/communication/mail/email/email-template-edit/email-template-edit.test.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-template-edit/email-template-edit.test.tsx
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/app/proj/${p}`,
 }));
 vi.mock("@blocks-communication/mail/hooks/use-email-template", () => ({

--- a/client/app/cross-modules/communication/mail/email/email-template-edit/email-template-edit.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-template-edit/email-template-edit.tsx
@@ -5,7 +5,7 @@ import PageBreadcrumb from "@/components/breadcrumb/breadcrumb";
 import { BREADCRUMB_CUSTOM_TITLES } from "@/constants/breadcrumb-custom-title";
 import { IEmailTemplate } from "@blocks-communication/mail/models/email";
 import { useNavigate } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import {
   useGetEmailTemplate,
   useSaveEmailTemplate,

--- a/client/app/cross-modules/communication/mail/email/email-usage/email-usage-details-breadcrumb.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-usage/email-usage-details-breadcrumb.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useNavigate } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import {
   Breadcrumb,
   BreadcrumbItem,

--- a/client/app/cross-modules/communication/mail/email/email-usage/email-usage-list.test.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-usage/email-usage-list.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   queryParams: { page: 0, pageSize: 10, search: "", status: "", startDate: "", endDate: "" },
 }));
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({ useScopedPath: () => (p: string) => `/s/${p}` }));
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({ useScopedPath: () => (p: string) => `/s/${p}` }));
 vi.mock("@blocks-communication/mail/hooks/use-email-usage", () => ({
   useGetEmailUsage: () => ({ data: h.data, isLoading: h.isLoading }),
 }));

--- a/client/app/cross-modules/communication/mail/email/email-usage/email-usage-list.tsx
+++ b/client/app/cross-modules/communication/mail/email/email-usage/email-usage-list.tsx
@@ -27,7 +27,7 @@ import {
   useEmailUsageFilterQueryParams,
 } from "@blocks-communication/mail/email/email-usage/email-usage-filter-toolbar";
 import { Link } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 const LoadingSkeleton = () => (
   <div className="grid w-full gap-2">
     {Array.from({ length: 5 }).map((_, index) => (

--- a/client/app/cross-modules/communication/mail/email/new-communication/new-communication.test.tsx
+++ b/client/app/cross-modules/communication/mail/email/new-communication/new-communication.test.tsx
@@ -12,10 +12,10 @@ const h = vi.hoisted(() => ({
 vi.mock("react-router", () => ({
   useNavigate: () => h.navigate,
 }));
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/scoped/${p}`,
 }));
 vi.mock("@/hooks/use-toast", () => ({ toast: h.toast }));

--- a/client/app/cross-modules/communication/mail/email/new-communication/new-communication.tsx
+++ b/client/app/cross-modules/communication/mail/email/new-communication/new-communication.tsx
@@ -10,8 +10,8 @@ import BeePluginStarter from "@blocks-communication/mail/components/bee-plugin-s
 import { blankTemplate } from "@blocks-communication/mail/constants/email-template";
 import { useSaveMailTemplate } from "@blocks-communication/mail/hooks/use-email-template";
 import { IEmailTemplate } from "@blocks-communication/mail/models/email";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useProjectStore } from "@seliseblocks/genesis-os";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { FileText, LayoutTemplate } from "lucide-react";
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router";

--- a/client/app/cross-modules/communication/mail/hooks/use-email-config.test.ts
+++ b/client/app/cross-modules/communication/mail/hooks/use-email-config.test.ts
@@ -13,7 +13,7 @@ import { emailService } from "@blocks-communication/mail/services/email.services
 import { useGetEmailConfigs, useSaveEmailConfig, useDeleteEmailConfig } from "./use-email-config";
 
 vi.mock("@blocks-communication/mail/services/email.services", () => mockEmailServiceFactory());
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 describe("Email Config Hooks", () => {
   beforeEach(() => {
@@ -63,7 +63,7 @@ describe("Email Config Hooks", () => {
     });
 
     it("should handle empty tenantId", async () => {
-      const { useProjectStore } = await import("@seliseblocks/blocks-kit");
+      const { useProjectStore } = await import("@seliseblocks/genesis-os");
       vi.mocked(useProjectStore).mockReturnValueOnce({
         selectedProject: { tenantId: "" },
       });

--- a/client/app/cross-modules/communication/mail/hooks/use-email-config.ts
+++ b/client/app/cross-modules/communication/mail/hooks/use-email-config.ts
@@ -1,4 +1,4 @@
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { emailService } from "@blocks-communication/mail/services/email.services";
 

--- a/client/app/cross-modules/communication/mail/hooks/use-email-template.test.ts
+++ b/client/app/cross-modules/communication/mail/hooks/use-email-template.test.ts
@@ -25,7 +25,7 @@ import {
 } from "./use-email-template";
 
 vi.mock("@blocks-communication/mail/services/email.services", () => mockEmailServiceFactory());
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 vi.mock("@/hooks/use-toast", () => mockToastFactory());
 
 describe("Email Template Hooks", () => {

--- a/client/app/cross-modules/communication/mail/hooks/use-email-template.ts
+++ b/client/app/cross-modules/communication/mail/hooks/use-email-template.ts
@@ -1,4 +1,4 @@
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { IEmailTemplate } from "@blocks-communication/mail/models/email";
 import { emailService } from "@blocks-communication/mail/services/email.services";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";

--- a/client/app/cross-modules/communication/mail/hooks/use-email-usage.test.ts
+++ b/client/app/cross-modules/communication/mail/hooks/use-email-usage.test.ts
@@ -14,7 +14,7 @@ import { useGetEmailUsage, useGetEmailUsageById } from "./use-email-usage";
 import { act } from "react";
 
 vi.mock("@blocks-communication/mail/services/email.services", () => mockEmailServiceFactory());
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 describe("Email Usage Hooks", () => {
   beforeEach(() => {
@@ -115,7 +115,7 @@ describe("Email Usage Hooks", () => {
     });
 
     it("should be disabled when tenantId is empty", async () => {
-      const { useProjectStore } = await import("@seliseblocks/blocks-kit");
+      const { useProjectStore } = await import("@seliseblocks/genesis-os");
       vi.mocked(useProjectStore).mockReturnValueOnce({
         selectedProject: { tenantId: "" },
       });
@@ -132,7 +132,7 @@ describe("Email Usage Hooks", () => {
     });
 
     it("should return empty data when tenantId is empty but query runs", async () => {
-      const { useProjectStore } = await import("@seliseblocks/blocks-kit");
+      const { useProjectStore } = await import("@seliseblocks/genesis-os");
       vi.mocked(useProjectStore).mockReturnValueOnce({
         selectedProject: { tenantId: "" },
       });
@@ -227,7 +227,7 @@ describe("Email Usage Hooks", () => {
     });
 
     it("should be disabled when tenantId is empty", async () => {
-      const { useProjectStore } = await import("@seliseblocks/blocks-kit");
+      const { useProjectStore } = await import("@seliseblocks/genesis-os");
       vi.mocked(useProjectStore).mockReturnValueOnce({
         selectedProject: { tenantId: "" },
       });
@@ -256,7 +256,7 @@ describe("Email Usage Hooks", () => {
     });
 
     it("should return null when tenantId is empty but query runs", async () => {
-      const { useProjectStore } = await import("@seliseblocks/blocks-kit");
+      const { useProjectStore } = await import("@seliseblocks/genesis-os");
       vi.mocked(useProjectStore).mockReturnValueOnce({
         selectedProject: { tenantId: "" },
       });

--- a/client/app/cross-modules/communication/mail/hooks/use-email-usage.ts
+++ b/client/app/cross-modules/communication/mail/hooks/use-email-usage.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { emailService } from "@blocks-communication/mail/services/email.services";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { EMAIL_USAGE_REFETCH_INTERVAL } from "@blocks-communication/mail/constants/email-usage";
 
 export const useGetEmailUsage = (

--- a/client/app/cross-modules/communication/notification/components/notification-configuration-list.test.tsx
+++ b/client/app/cross-modules/communication/notification/components/notification-configuration-list.test.tsx
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => ({
   setQueryParams: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("../hooks/use-notification-config", () => ({

--- a/client/app/cross-modules/communication/notification/components/notification-configuration-list.tsx
+++ b/client/app/cross-modules/communication/notification/components/notification-configuration-list.tsx
@@ -29,7 +29,7 @@ import {
 import { toast } from "@/hooks/use-toast";
 import { Dialog } from "@/components/ui-kits/dialog/dialog";
 import { Button } from "@/components/ui-kits/button/button";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useNotificationConfigsFilterQueryParams } from "./notification-configs-filter-toolbar";
 import { useQueryState, parseAsBoolean } from "nuqs";
 

--- a/client/app/cross-modules/communication/notification/modals/new-notification-configuration.test.tsx
+++ b/client/app/cross-modules/communication/notification/modals/new-notification-configuration.test.tsx
@@ -11,7 +11,7 @@ const h = vi.hoisted(() => ({
   showErrorToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("../hooks/use-notification-config", () => ({

--- a/client/app/cross-modules/communication/notification/modals/new-notification-configuration.tsx
+++ b/client/app/cross-modules/communication/notification/modals/new-notification-configuration.tsx
@@ -6,7 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { channelsToNotify, notificationTypes } from "../constants/notification.constant";
 import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
 import { useEffect } from "react";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { showErrorToast, toast } from "@/hooks/use-toast";
 import { isErrorWithErrors } from "@/lib/error";
 import {

--- a/client/app/cross-modules/devops/components/deployment-steps/render-repos/render-provider.test.tsx
+++ b/client/app/cross-modules/devops/components/deployment-steps/render-repos/render-provider.test.tsx
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "proj-1" } }),
 }));
 vi.mock("@/cross-modules/devops/hooks/github-info", () => ({

--- a/client/app/cross-modules/devops/components/deployment-steps/render-repos/render-provider.tsx
+++ b/client/app/cross-modules/devops/components/deployment-steps/render-repos/render-provider.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui-kits/button/button";
 import { useNavigate } from "react-router";
 import { useValidateAuthorization } from "@/cross-modules/devops/hooks/github-info";
 import { IProviderDestination } from "@/cross-modules/devops/models/utils";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 interface ProviderButtonsProps extends IProviderDestination {
   onClose?: (verifyAuth?: boolean) => void | Promise<void>;
   extraState?: string;

--- a/client/app/cross-modules/devops/hooks/github-info.extra.test.ts
+++ b/client/app/cross-modules/devops/hooks/github-info.extra.test.ts
@@ -13,7 +13,7 @@ import {
   useChangeRepoSpecs,
 } from "./github-info";
 
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 vi.mock("../services/github-info.service", () => ({
   githubInfoService: {
     revokeAccess: vi.fn(),

--- a/client/app/cross-modules/devops/hooks/github-info.test.ts
+++ b/client/app/cross-modules/devops/hooks/github-info.test.ts
@@ -19,7 +19,7 @@ import {
   useChangeRepoSpecs,
 } from "./github-info";
 
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 vi.mock("../services/github-info.service", () => ({
   githubInfoService: {
     verifyAuthorization: vi.fn(),

--- a/client/app/cross-modules/devops/hooks/github-info.ts
+++ b/client/app/cross-modules/devops/hooks/github-info.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { githubInfoService } from "../services/github-info.service";
 import { IBuildApiResponse } from "../models/deployed-logs";
 import { IChangeRepoSpecs, IChangeSettings, IManualDeploymentPayload } from "../models/utils";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 
 export const useGithubVerification = (code: string) => {
   const projectKey = useProjectStore().selectedProject?.tenantId || "";

--- a/client/app/cross-modules/identifier/components/service-card/service-card.test.tsx
+++ b/client/app/cross-modules/identifier/components/service-card/service-card.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
 vi.mock("@/hooks/use-lmt-base-path", () => ({ useLmtBasePath: () => "/app/proj-1/lmt" }));
 vi.mock("@/lib/runtime-env", () => ({ getRuntimeEnv: () => "https://os.example.com" }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useCopyToClipboard: () => ({ copy: h.copy }),
 }));
 vi.mock("@/hooks/use-toast", () => ({

--- a/client/app/cross-modules/identifier/components/service-card/service-card.tsx
+++ b/client/app/cross-modules/identifier/components/service-card/service-card.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui-kits/dropdown-menu/dropdown-menu";
 import { MaskedText } from "@/components/masked-text";
-import { useCopyToClipboard } from "@seliseblocks/blocks-kit/hooks";
+import { useCopyToClipboard } from "@seliseblocks/genesis-os/hooks";
 import { showSuccessToast } from "@/hooks/use-toast";
 import { Badge } from "@/components/ui-kits/badge/badge";
 import { AccordionTrigger } from "@/components/ui-kits/accordion/accordion";

--- a/client/app/cross-modules/identifier/models/project.model.ts
+++ b/client/app/cross-modules/identifier/models/project.model.ts
@@ -1,6 +1,6 @@
 import { DomainAction } from "@/pages/dashboard/components/domain";
 import { GRANT_TYPES, SSO_PROVIDERS } from "@blocks-idp/authentication/constants";
-import { IDomain } from "@seliseblocks/blocks-kit/models";
+import { IDomain } from "@seliseblocks/genesis-os/models";
 
 export interface IProject {
   itemId: string;

--- a/client/app/cross-modules/idp/authentication/components/client-credentials/client-credential-card.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/client-credentials/client-credential-card.test.tsx
@@ -10,7 +10,7 @@ const { mutateAsync, showErrorToast, showSuccessToast } = vi.hoisted(() => ({
 
 if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "t1" } }),
 }));
 vi.mock("@blocks-idp/authentication/hooks/use-auth-clients", () => ({

--- a/client/app/cross-modules/idp/authentication/components/client-credentials/client-credential-card.tsx
+++ b/client/app/cross-modules/idp/authentication/components/client-credentials/client-credential-card.tsx
@@ -7,7 +7,7 @@ import { format } from "date-fns";
 import { IClientCredentialsConfig } from "@blocks-idp/authentication/models/auth.oidc.model";
 import { Button } from "@/components/ui-kits/button/button";
 import { useDeleteAuthClient } from "@blocks-idp/authentication/hooks/use-auth-clients";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { Dialog } from "@/components/ui-kits/dialog/dialog";
 import { ConfirmationModal } from "@/components/confirmation-modal/confirmation-modal";

--- a/client/app/cross-modules/idp/authentication/components/client-credentials/client-credentials.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/client-credentials/client-credentials.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   listProps: undefined as Record<string, unknown> | undefined,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/authentication/hooks/use-auth-clients", () => ({

--- a/client/app/cross-modules/idp/authentication/components/client-credentials/client-credentials.tsx
+++ b/client/app/cross-modules/idp/authentication/components/client-credentials/client-credentials.tsx
@@ -1,6 +1,6 @@
 import { ClientCredentialList } from "./client-credentials-list";
 import { useListAuthClientCredentials } from "@blocks-idp/authentication/hooks/use-auth-clients";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { parseAsBoolean, parseAsString, useQueryState } from "nuqs";
 
 // type SummaryTileProps = {

--- a/client/app/cross-modules/idp/authentication/components/create-client-credential/add-client-credential-permission.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/create-client-credential/add-client-credential-permission.test.tsx
@@ -6,7 +6,7 @@ const h = vi.hoisted(() => ({
   useGetPermissions: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-permission", () => ({

--- a/client/app/cross-modules/idp/authentication/components/create-client-credential/add-client-credential-permission.tsx
+++ b/client/app/cross-modules/idp/authentication/components/create-client-credential/add-client-credential-permission.tsx
@@ -24,7 +24,7 @@ import {
   TableRow,
 } from "@/components/ui-kits/table/table";
 import { cn } from "@/lib/utils";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetPermissions } from "@blocks-idp/iam/hooks/use-permission";
 import { IPermission, RESOURCE_TYPE } from "@blocks-idp/iam/models/permission";
 import { Plus } from "lucide-react";

--- a/client/app/cross-modules/idp/authentication/components/create-client-credential/add-client-credential-role.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/create-client-credential/add-client-credential-role.test.tsx
@@ -6,7 +6,7 @@ const h = vi.hoisted(() => ({
   useGetRoles: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-roles", () => ({

--- a/client/app/cross-modules/idp/authentication/components/create-client-credential/add-client-credential-role.tsx
+++ b/client/app/cross-modules/idp/authentication/components/create-client-credential/add-client-credential-role.tsx
@@ -13,7 +13,7 @@ import {
   DialogTrigger,
 } from "@/components/ui-kits/dialog/dialog";
 import { Pagination } from "@/components/ui-kits/pagination/pagination";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetRoles } from "@blocks-idp/iam/hooks/use-roles";
 import { IRole } from "@blocks-idp/iam/models/role";
 import { Plus } from "lucide-react";

--- a/client/app/cross-modules/idp/authentication/components/create-client-credential/create-client-credential.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/create-client-credential/create-client-credential.test.tsx
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/authentication/hooks/use-auth-clients", () => ({

--- a/client/app/cross-modules/idp/authentication/components/create-client-credential/create-client-credential.tsx
+++ b/client/app/cross-modules/idp/authentication/components/create-client-credential/create-client-credential.tsx
@@ -22,7 +22,7 @@ import { Switch } from "@/components/ui-kits/switch/switch";
 import { Plus, KeyRound } from "lucide-react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useSaveAuthClient } from "@blocks-idp/authentication/hooks/use-auth-clients";
 import { useForm } from "react-hook-form";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";

--- a/client/app/cross-modules/idp/authentication/components/create-oidc/create-oidc.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/create-oidc/create-oidc.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => {
+vi.mock("@seliseblocks/genesis-os", () => {
   const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
   return {
     useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),

--- a/client/app/cross-modules/idp/authentication/components/create-oidc/create-oidc.tsx
+++ b/client/app/cross-modules/idp/authentication/components/create-oidc/create-oidc.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui-kits/form/form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useFieldArray, useForm } from "react-hook-form";
 import { Info, Plus, Pencil, X } from "lucide-react";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";

--- a/client/app/cross-modules/idp/authentication/components/identity-provider/identity-provider-form-dialog.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/identity-provider/identity-provider-form-dialog.test.tsx
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@/hooks/use-toast", () => ({

--- a/client/app/cross-modules/idp/authentication/components/identity-provider/identity-provider-form-dialog.tsx
+++ b/client/app/cross-modules/idp/authentication/components/identity-provider/identity-provider-form-dialog.tsx
@@ -37,7 +37,7 @@ import {
   toRoleStubs,
   buildIdentityProviderPayload,
 } from "./identity-provider-form.util";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { getBlocksOidcWellKnownUrl } from "@/lib/get-api-path";
 import { CopyToClipboardButton } from "@/components/copy-to-clipboard-button";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";

--- a/client/app/cross-modules/idp/authentication/components/identity-provider/identity-provider-list.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/identity-provider/identity-provider-list.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => {
+vi.mock("@seliseblocks/genesis-os", () => {
   const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
   return {
     Tooltip: Passthrough,

--- a/client/app/cross-modules/idp/authentication/components/oidc/oidc-branding-form.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/oidc/oidc-branding-form.test.tsx
@@ -13,7 +13,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "t1" } }),
 }));
 vi.mock("@blocks-idp/authentication/contexts/oidc-branding-header-context", () => ({

--- a/client/app/cross-modules/idp/authentication/components/oidc/oidc-branding-form.tsx
+++ b/client/app/cross-modules/idp/authentication/components/oidc/oidc-branding-form.tsx
@@ -14,7 +14,7 @@ import {
 } from "@blocks-idp/authentication/hooks/use-auth-oidc";
 import { useGetPreSignedUrlForUpload, useUploadFile } from "@blocks-storage/hooks/use-storage-file";
 import { storageService } from "@blocks-storage/services/storage.service";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useOidcBrandingHeader } from "@blocks-idp/authentication/contexts/oidc-branding-header-context";
 import { OidcLoginPreview } from "./oidc-login-preview";
 import { buildOidcSavePayload } from "./build-oidc-save-payload";

--- a/client/app/cross-modules/idp/authentication/components/oidc/oidc-card.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/oidc/oidc-card.test.tsx
@@ -14,10 +14,10 @@ vi.mock("react-router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("react-router")>()),
   useNavigate: () => h.navigate,
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/scoped/${p}`,
 }));
-vi.mock("@seliseblocks/blocks-kit", () => {
+vi.mock("@seliseblocks/genesis-os", () => {
   const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
   return {
     useProjectStore: () => ({ selectedProject: { tenantId: "t1" } }),

--- a/client/app/cross-modules/idp/authentication/components/oidc/oidc-card.tsx
+++ b/client/app/cross-modules/idp/authentication/components/oidc/oidc-card.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { format } from "date-fns";
 import { ChevronRight, LayoutTemplate, RotateCw, Shield, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui-kits/badge/badge";
@@ -26,7 +26,7 @@ import {
   IDeleteOidcClientPayload,
   IOidcConfig,
 } from "@blocks-idp/authentication/models/auth.oidc.model";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { CreateOIDC } from "../create-oidc/create-oidc";
 import { KVDetailItem } from "../kv-detail-item";
 import { CopyToClipboardButton } from "@/components/copy-to-clipboard-button";

--- a/client/app/cross-modules/idp/authentication/components/oidc/oidc-list.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/oidc/oidc-list.test.tsx
@@ -7,7 +7,7 @@ const h = vi.hoisted(() => ({
   data: undefined as unknown,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/authentication/hooks/use-auth-oidc", () => ({

--- a/client/app/cross-modules/idp/authentication/components/oidc/oidc-list.tsx
+++ b/client/app/cross-modules/idp/authentication/components/oidc/oidc-list.tsx
@@ -1,6 +1,6 @@
 import { useGetAuthOidcCredentials } from "@blocks-idp/authentication/hooks/use-auth-oidc";
 import { useMemo } from "react";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { Card, CardContent } from "@/components/ui-kits/card/card";
 import { EmptyState } from "@/components/ui-kits/empty-state";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";

--- a/client/app/cross-modules/idp/authentication/components/sso-initial-permissions/add-sso-permission/add-sso-permission.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/sso-initial-permissions/add-sso-permission/add-sso-permission.test.tsx
@@ -7,7 +7,7 @@ const h = vi.hoisted(() => ({
   useGetPermissions: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-permission", () => ({

--- a/client/app/cross-modules/idp/authentication/components/sso-initial-permissions/add-sso-permission/add-sso-permission.tsx
+++ b/client/app/cross-modules/idp/authentication/components/sso-initial-permissions/add-sso-permission/add-sso-permission.tsx
@@ -24,7 +24,7 @@ import {
   TableRow,
 } from "@/components/ui-kits/table/table";
 import { cn } from "@/lib/utils";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetPermissions } from "@blocks-idp/iam/hooks/use-permission";
 import { IPermission, RESOURCE_TYPE } from "@blocks-idp/iam/models/permission";
 import { Plus } from "lucide-react";

--- a/client/app/cross-modules/idp/authentication/components/sso-initial-roles/add-sso-role/add-sso-role.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/sso-initial-roles/add-sso-role/add-sso-role.test.tsx
@@ -38,7 +38,7 @@ if (!Element.prototype.scrollIntoView) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let rolesResult: any = { data: undefined, isLoading: false };
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 

--- a/client/app/cross-modules/idp/authentication/components/sso-initial-roles/add-sso-role/add-sso-role.tsx
+++ b/client/app/cross-modules/idp/authentication/components/sso-initial-roles/add-sso-role/add-sso-role.tsx
@@ -13,7 +13,7 @@ import {
   DialogTrigger,
 } from "@/components/ui-kits/dialog/dialog";
 import { Pagination } from "@/components/ui-kits/pagination/pagination";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetRoles } from "@blocks-idp/iam/hooks/use-roles";
 import { IRole } from "@blocks-idp/iam/models/role";
 import { Plus } from "lucide-react";

--- a/client/app/cross-modules/idp/authentication/components/sso-initial-roles/sso-roles-list.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/sso-initial-roles/sso-roles-list.test.tsx
@@ -31,7 +31,7 @@ vi.mock("react-router", async (importOriginal) => {
   return { ...actual, useNavigate: () => navigate };
 });
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (path: string) => `/app/tenant-1/${path}`,
 }));
 

--- a/client/app/cross-modules/idp/authentication/components/sso-initial-roles/sso-roles-list.tsx
+++ b/client/app/cross-modules/idp/authentication/components/sso-initial-roles/sso-roles-list.tsx
@@ -9,7 +9,7 @@ import {
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import { useMemo } from "react";
 import { useNavigate } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { IRole } from "@blocks-idp/iam/models/role";
 import { Badge } from "@/components/ui-kits/badge/badge";
 import { DeleteSSORole } from "./delete-sso-role";

--- a/client/app/cross-modules/idp/authentication/components/sso-provider-card/sso-provider-card.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/sso-provider-card/sso-provider-card.test.tsx
@@ -35,7 +35,7 @@ if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {};
 }
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (path: string) => `/app/tenant-1/${path}`,
   useTheme: () => ({ theme: "light" }),
 }));

--- a/client/app/cross-modules/idp/authentication/components/sso-provider-card/sso-provider-card.tsx
+++ b/client/app/cross-modules/idp/authentication/components/sso-provider-card/sso-provider-card.tsx
@@ -11,10 +11,10 @@ import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { ISsoProviderConfigurationWithMeta } from "@blocks-idp/authentication/models/sso.model";
 import { EllipsisVertical } from "lucide-react";
 import { Link } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { SSoProviderStatusToggle } from "../sso-provider-status-toggle";
 import { useMemo, useState } from "react";
-import { useTheme } from "@seliseblocks/blocks-kit/hooks";
+import { useTheme } from "@seliseblocks/genesis-os/hooks";
 type SSOProviderCardProps = {
   configuration: ISsoProviderConfigurationWithMeta;
 };

--- a/client/app/cross-modules/idp/authentication/components/sso-provider-status-toggle/sso-provider-status-toggle.test.tsx
+++ b/client/app/cross-modules/idp/authentication/components/sso-provider-status-toggle/sso-provider-status-toggle.test.tsx
@@ -27,7 +27,7 @@ const mutateAsync = vi.fn();
 const showErrorToast = vi.fn();
 const showSuccessToast = vi.fn();
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 

--- a/client/app/cross-modules/idp/authentication/components/sso-provider-status-toggle/sso-provider-status-toggle.tsx
+++ b/client/app/cross-modules/idp/authentication/components/sso-provider-status-toggle/sso-provider-status-toggle.tsx
@@ -2,7 +2,7 @@ import { ConfirmationModal } from "@/components/confirmation-modal/confirmation-
 import { Dialog } from "@/components/ui-kits/dialog/dialog";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { isErrorWithErrors } from "@/lib/error";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useUpdateSsoCredentialStatus } from "@blocks-idp/authentication/hooks/use-sso";
 import { ISsoProviderConfigurationWithMeta } from "@blocks-idp/authentication/models/sso.model";
 type SSoProviderStatusToggleProps = {

--- a/client/app/cross-modules/idp/authentication/hooks/use-auth-oidc.test.ts
+++ b/client/app/cross-modules/idp/authentication/hooks/use-auth-oidc.test.ts
@@ -27,7 +27,7 @@ vi.mock("@blocks-idp/authentication/services/auth-clients-oidc.service", () =>
   mockAuthOidcServiceFactory(),
 );
 
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 type BlocksWindow = Window & {
   __BLOCKS_ENV__?: Record<string, string | undefined>;

--- a/client/app/cross-modules/idp/authentication/hooks/use-auth-oidc.ts
+++ b/client/app/cross-modules/idp/authentication/hooks/use-auth-oidc.ts
@@ -1,7 +1,7 @@
 import { authOidc } from "@blocks-idp/authentication/services/auth-clients-oidc.service";
 import { ISaveOidcCredentialPayload } from "@blocks-idp/authentication/models/auth.oidc.model";
 import { getBlocksOidcWellKnownUrl } from "@/lib/get-api-path";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useGetAuthOidcCredentials = (options: { projectKey: string }) => {

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/authentication-config.test.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/authentication-config.test.tsx
@@ -8,7 +8,7 @@ vi.mock("react-router", () => ({
   Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
   Outlet: () => <div data-testid="outlet" />,
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({ useScopedPath: () => (p: string) => `/scoped/${p}` }));
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({ useScopedPath: () => (p: string) => `/scoped/${p}` }));
 vi.mock("@blocks-communication/mail/email/email-configure/email-configure", () => ({
   EmailConfiguration: () => <div data-testid="email-config" />,
 }));

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/authentication-config.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/authentication-config.tsx
@@ -10,7 +10,7 @@ import { EmailConfiguration } from "@blocks-communication/mail/email/email-confi
 import { Settings } from "lucide-react";
 import { parseAsBoolean, useQueryState } from "nuqs";
 import { Link, Outlet, useLocation } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { PrimaryButton } from "@/components/action-buttons/primary-button";
 import { AddRole } from "@blocks-idp/iam/modules/role-management";
 

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/add-edit-provider-modal.test.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/add-edit-provider-modal.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/hooks/use-toast", () => ({
   showSuccessToast: (...args: unknown[]) => showSuccessToast(...args),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/add-edit-provider-modal.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/add-edit-provider-modal.tsx
@@ -19,7 +19,7 @@ import { Label } from "@/components/ui-kits/label/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui-kits/radio-group/radio-group";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { IGetPublicCertificateResponse } from "@blocks-identifier/models/project.model";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { providers } from "@blocks-idp/authentication/constants/authentication.constant";
 import {
   useSavePublicCertificates,

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/certificates.test.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/certificates.test.tsx
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
   isJwtClaimLoading: false,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/authentication/hooks/use-identifier", () => ({

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/certificates.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/certificates.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent } from "@/components/ui-kits/card/card";
 import { Banner } from "@/components/ui-kits/banner/banner";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetSavedPublicCertificates } from "@blocks-idp/authentication/hooks/use-identifier";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { EmptyConfiguration } from "./empty-configuration";

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/map-jwt-claim-modal.test.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/map-jwt-claim-modal.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@/hooks/use-toast", () => ({
   showSuccessToast: (...a: unknown[]) => showSuccessToast(...a),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/map-jwt-claim-modal.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/general/certificates/map-jwt-claim-modal.tsx
@@ -24,7 +24,7 @@ import {
 import { Textarea } from "@/components/ui-kits/textarea/textarea";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useAddJwtClaim, useGetJwtClaim } from "@blocks-idp/authentication/hooks/use-jwt-claim";
 import { JwtClaimPayload } from "@blocks-idp/authentication/models/jwt.claim.model";
 import { jwtDecode } from "jwt-decode";

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/sso/sso-provider-list/sso-provider-list.test.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/sso/sso-provider-list/sso-provider-list.test.tsx
@@ -7,7 +7,7 @@ const h = vi.hoisted(() => ({
   cardProps: [] as Array<Record<string, unknown>>,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/authentication/hooks/use-auth-config", () => ({

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/sso/sso-provider-list/sso-provider-list.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/sso/sso-provider-list/sso-provider-list.tsx
@@ -1,4 +1,4 @@
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import {
   SSOProviderCard,
   SSOProviderCardSkelton,

--- a/client/app/cross-modules/idp/authentication/pages/authentication-config/sso/sso.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/authentication-config/sso/sso.tsx
@@ -1,4 +1,4 @@
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { SSOProviderList } from "./sso-provider-list";
 export const SSO = () => {
   const { tenantId } = useProjectStore().selectedProject || { tenantId: "" };

--- a/client/app/cross-modules/idp/authentication/pages/mfa-check/mfa-check-form.test.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/mfa-check/mfa-check-form.test.tsx
@@ -11,7 +11,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit/store", () => ({
+vi.mock("@seliseblocks/genesis-os/store", () => ({
   useAuthStore: () => ({ setAuthenticated: h.setAuthenticated }),
 }));
 vi.mock("@blocks-idp/mfa/hooks/use-resend-otp", () => ({

--- a/client/app/cross-modules/idp/authentication/pages/mfa-check/mfa-check-form.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/mfa-check/mfa-check-form.tsx
@@ -9,7 +9,7 @@ import {
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui-kits/input-otp/input-otp";
 import { showErrorToast } from "@/hooks/use-toast";
 import { isErrorWithErrors } from "@/lib/error";
-import { useAuthStore } from "@seliseblocks/blocks-kit/store";
+import { useAuthStore } from "@seliseblocks/genesis-os/store";
 import { useResendOtp } from "@blocks-idp/mfa/hooks/use-resend-otp";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "react-router";

--- a/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-blocks-form.test.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-blocks-form.test.tsx
@@ -8,7 +8,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/authentication/hooks/use-sso", () => ({

--- a/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-blocks-form.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-blocks-form.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui-kits/button/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui-kits/card/card";
 import { Form } from "@/components/ui-kits/form/form";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import {
   useSaveGetOIDCCredential,
   useSaveOIDCCredential,

--- a/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-blocks-own-sso-form.test.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-blocks-own-sso-form.test.tsx
@@ -27,7 +27,7 @@ const mutateAsync = vi.fn();
 const showErrorToast = vi.fn();
 const showSuccessToast = vi.fn();
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 

--- a/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-blocks-own-sso-form.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-blocks-own-sso-form.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui-kits/button/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui-kits/card/card";
 import { Form } from "@/components/ui-kits/form/form";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { SSO_PROVIDERS } from "@blocks-idp/authentication/constants/sso-providers.constant";
 import { useSaveSsoCredential } from "@blocks-idp/authentication/hooks/use-sso";
 import { ISsoProviderConfiguration } from "@blocks-idp/authentication/models/sso.model";

--- a/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-forms.test.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-forms.test.tsx
@@ -10,10 +10,10 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/app/proj/${p}`,
 }));
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));

--- a/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-forms.tsx
+++ b/client/app/cross-modules/idp/authentication/pages/sso-configuration/sso-provider-config/sso-provider-config-forms/sso-provider-config-forms.tsx
@@ -5,7 +5,7 @@ import { SSOProviderConfigLinkedINForm } from "./sso-provider-config-linkedin-fo
 import { SSO_PROVIDERS } from "@blocks-idp/authentication/constants/sso-providers.constant";
 import { SSOProviderConfigMicrosoftForm } from "./sso-provider-config-microsoft-form";
 import { SSOProviderConfigXForm } from "./sso-provider-config-x-form";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import {
   useGetSsoCredentialById,
   useSaveSsoCredential,
@@ -14,7 +14,7 @@ import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { isErrorWithErrors } from "@/lib/error";
 import { ISsoProviderConfiguration } from "@blocks-idp/authentication/models/sso.model";
 import { useNavigate } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { SSOProviderConfigOwnSSOForm } from "./sso-provider-config-blocks-own-sso-form";
 export type SsoConfigFormsProps = {
   provider: SSO_PROVIDERS;

--- a/client/app/cross-modules/idp/captcha/hooks/use-captcha.test.ts
+++ b/client/app/cross-modules/idp/captcha/hooks/use-captcha.test.ts
@@ -1,8 +1,8 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { useTheme } from "@seliseblocks/blocks-kit/hooks";
+import { useTheme } from "@seliseblocks/genesis-os/hooks";
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useTheme: vi.fn(() => ({ theme: "light" })),
 }));
 

--- a/client/app/cross-modules/idp/captcha/hooks/use-captcha.ts
+++ b/client/app/cross-modules/idp/captcha/hooks/use-captcha.ts
@@ -1,5 +1,5 @@
 import { CaptchaProps, CaptchaRef } from "@/components/captcha/index.type";
-import { useTheme } from "@seliseblocks/blocks-kit/hooks";
+import { useTheme } from "@seliseblocks/genesis-os/hooks";
 import { useCallback, useRef, useState } from "react";
 
 type UseCaptchaProps = {

--- a/client/app/cross-modules/idp/captcha/modals/configure-captcha-modal/configure-captcha-modal.test.tsx
+++ b/client/app/cross-modules/idp/captcha/modals/configure-captcha-modal/configure-captcha-modal.test.tsx
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("../../hooks/use-captcha-config", () => ({

--- a/client/app/cross-modules/idp/captcha/modals/configure-captcha-modal/configure-captcha-modal.tsx
+++ b/client/app/cross-modules/idp/captcha/modals/configure-captcha-modal/configure-captcha-modal.tsx
@@ -31,7 +31,7 @@ import {
   SelectValue,
 } from "@/components/ui-kits/select/select";
 import { Button } from "@/components/ui-kits/button/button";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { ReactNode, useEffect, useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 type ConfigureCaptchaModalProps = {

--- a/client/app/cross-modules/idp/captcha/pages/configure-captcha/configure-captcha.tsx
+++ b/client/app/cross-modules/idp/captcha/pages/configure-captcha/configure-captcha.tsx
@@ -1,5 +1,5 @@
 import { ConfigureCaptchaList } from "./configure-captcha-list";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetCaptchaConfigs } from "../../hooks/use-captcha-config";
 export const ConfigureCaptcha = () => {
   const tenantId = useProjectStore().selectedProject?.tenantId || "";

--- a/client/app/cross-modules/idp/iam/components/permission-group-combobox/permission-group-combobox.test.tsx
+++ b/client/app/cross-modules/idp/iam/components/permission-group-combobox/permission-group-combobox.test.tsx
@@ -6,7 +6,7 @@ const h = vi.hoisted(() => ({
   useGetResourceGroup: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-permission", () => ({

--- a/client/app/cross-modules/idp/iam/components/permission-group-combobox/permission-group-combobox.tsx
+++ b/client/app/cross-modules/idp/iam/components/permission-group-combobox/permission-group-combobox.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui-kits/command/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui-kits/popover/popover";
 import { cn } from "@/lib/utils";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetResourceGroup } from "@blocks-idp/iam/hooks/use-permission";
 import { ChevronDown, Plus, X } from "lucide-react";
 import { useMemo, useState, type MouseEvent } from "react";

--- a/client/app/cross-modules/idp/iam/components/profile-mfa/profile-mfa.test.tsx
+++ b/client/app/cross-modules/idp/iam/components/profile-mfa/profile-mfa.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
 vi.mock("@blocks-idp/mfa/hooks/use-mfa-config", () => ({
   useGetProfileMFAConfig: () => ({ data: h.data, isLoading: h.isLoading }),
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/app/proj/${p}`,
 }));
 vi.mock("./profile-mfa-detail", () => ({ ProfileMFADetails: () => <div data-testid="details" /> }));

--- a/client/app/cross-modules/idp/iam/components/profile-mfa/profile-mfa.tsx
+++ b/client/app/cross-modules/idp/iam/components/profile-mfa/profile-mfa.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui-kits/c
 import { ProfileMFADetails } from "./profile-mfa-detail";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { Link } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { Button } from "@/components/ui-kits/button/button";
 import { createContext, useState } from "react";
 import { ProfileMfaMethodSelectList } from "./user-mfa-confirmation/profile-mfa-methods-select-list";

--- a/client/app/cross-modules/idp/iam/components/user-mfa/user-mfa.test.tsx
+++ b/client/app/cross-modules/idp/iam/components/user-mfa/user-mfa.test.tsx
@@ -20,7 +20,7 @@ vi.mock("@blocks-idp/iam/hooks/use-user", () => ({
     isFetching: h.userFetching,
   }),
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/app/proj/${p}`,
 }));
 vi.mock("./user-mfa-confirmation/user-mfa-confirmation-disable", () => ({

--- a/client/app/cross-modules/idp/iam/components/user-mfa/user-mfa.tsx
+++ b/client/app/cross-modules/idp/iam/components/user-mfa/user-mfa.tsx
@@ -5,7 +5,7 @@ import { useGetUserById } from "@blocks-idp/iam/hooks/use-user";
 import { useGetMFAConfig } from "@blocks-idp/mfa/hooks/use-mfa-config";
 import { createContext, useContext, useState } from "react";
 import { Link } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { UserMFAConfirmationDisable } from "./user-mfa-confirmation/user-mfa-confirmation-disable";
 import { UserMFADetails } from "./user-mfa-detail";
 type UserMFAProps = {

--- a/client/app/cross-modules/idp/iam/components/users-role-permission-table-toolbar/users-role-permission-table-toolbar.tsx
+++ b/client/app/cross-modules/idp/iam/components/users-role-permission-table-toolbar/users-role-permission-table-toolbar.tsx
@@ -3,7 +3,7 @@ import { Table } from "@tanstack/react-table";
 import { Button } from "@/components/ui-kits/button/button";
 import { Cross2Icon } from "@radix-ui/react-icons";
 import { DataTableFacetedFilter } from "@/components/data-table-faceted-filter/data-table-faceted-filter";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 import {
   Sheet,
   SheetClose,

--- a/client/app/cross-modules/idp/iam/components/users-role-table-toolbar/users-role-table-toolbar.tsx
+++ b/client/app/cross-modules/idp/iam/components/users-role-table-toolbar/users-role-table-toolbar.tsx
@@ -6,7 +6,7 @@ import { DataTableFacetedFilter } from "@/components/data-table-faceted-filter/d
 import { DateRangeFilter } from "@/components/date-range-filter/date-range-filter";
 import { translation } from "@blocks-localization/models/language";
 import { DateRange } from "react-day-picker";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 import {
   Sheet,
   SheetClose,

--- a/client/app/cross-modules/idp/iam/hooks/use-iam-configuration.test.ts
+++ b/client/app/cross-modules/idp/iam/hooks/use-iam-configuration.test.ts
@@ -13,7 +13,7 @@ import { useGetIamConfiguration, useSaveIamConfiguration } from "./use-iam-confi
 vi.mock("@blocks-idp/iam/services/configuration.service", () =>
   mockIamConfigurationServiceFactory(),
 );
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 describe("use-iam-configuration hooks", () => {
   beforeEach(() => {

--- a/client/app/cross-modules/idp/iam/hooks/use-iam-configuration.ts
+++ b/client/app/cross-modules/idp/iam/hooks/use-iam-configuration.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { configurationService } from "@blocks-idp/iam/services/configuration.service";
 
 export const useGetIamConfiguration = () => {

--- a/client/app/cross-modules/idp/iam/hooks/use-user.extra.test.ts
+++ b/client/app/cross-modules/idp/iam/hooks/use-user.extra.test.ts
@@ -40,7 +40,7 @@ vi.mock("@blocks-idp/iam/services/user.service", () => {
 });
 
 const mockSetUser = vi.fn();
-vi.mock("@seliseblocks/blocks-kit/store", () => ({
+vi.mock("@seliseblocks/genesis-os/store", () => ({
   useAuthStore: vi.fn(() => ({ setUser: mockSetUser, user: undefined })),
 }));
 

--- a/client/app/cross-modules/idp/iam/hooks/use-user.test.ts
+++ b/client/app/cross-modules/idp/iam/hooks/use-user.test.ts
@@ -33,7 +33,7 @@ import {
 vi.mock("@blocks-idp/iam/services/user.service", () => mockUserServiceFactory());
 
 const mockSetUser = vi.fn();
-vi.mock("@seliseblocks/blocks-kit/store", () => ({
+vi.mock("@seliseblocks/genesis-os/store", () => ({
   useAuthStore: vi.fn(() => ({ setUser: mockSetUser })),
 }));
 

--- a/client/app/cross-modules/idp/iam/hooks/use-user.ts
+++ b/client/app/cross-modules/idp/iam/hooks/use-user.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@seliseblocks/blocks-kit/store";
+import { useAuthStore } from "@seliseblocks/genesis-os/store";
 import {
   IGetUserByIdPayload,
   IGetUserRolesPayload,

--- a/client/app/cross-modules/idp/iam/modules/organization-management/add-organization/add-organization.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/add-organization/add-organization.test.tsx
@@ -29,7 +29,7 @@ const { mutateAsync, showErrorToast, showSuccessToast } = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({
     selectedProject: { itemId: "p1", tenantId: "t1" },
   }),

--- a/client/app/cross-modules/idp/iam/modules/organization-management/add-organization/add-organization.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/add-organization/add-organization.tsx
@@ -24,7 +24,7 @@ import {
   FormMessage,
 } from "@/components/ui-kits/form/form";
 import { z } from "zod";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useSaveOrganization } from "@blocks-idp/iam/hooks/use-organization";
 import { Plus } from "lucide-react";
 interface AddOrganizationProps {

--- a/client/app/cross-modules/idp/iam/modules/organization-management/organization-config/organization-config.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/organization-config/organization-config.test.tsx
@@ -13,7 +13,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: h.tenantId } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({

--- a/client/app/cross-modules/idp/iam/modules/organization-management/organization-config/organization-config.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/organization-config/organization-config.tsx
@@ -15,7 +15,7 @@ import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Form, FormControl, FormField, FormItem, FormLabel } from "@/components/ui-kits/form/form";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useSaveOrganizationConfig } from "@blocks-idp/iam/hooks/use-organization";
 import { useGetRoles } from "@blocks-idp/iam/hooks/use-roles";
 import {

--- a/client/app/cross-modules/idp/iam/modules/organization-management/organization-users/invite-organization-user.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/organization-users/invite-organization-user.test.tsx
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-user", () => ({

--- a/client/app/cross-modules/idp/iam/modules/organization-management/organization-users/invite-organization-user.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/organization-users/invite-organization-user.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui-kits/form/form";
 import { useAddUser } from "@blocks-idp/iam/hooks/use-user";
 import { z } from "zod";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useState } from "react";
 import { isErrorWithErrors } from "@/lib/error";
 import { PrimaryButton } from "@/components/action-buttons/primary-button";

--- a/client/app/cross-modules/idp/iam/modules/organization-management/organization-users/organization-users.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/organization-users/organization-users.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   isFetching: false,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-user", () => ({

--- a/client/app/cross-modules/idp/iam/modules/organization-management/organization-users/organization-users.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/organization-users/organization-users.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui-kits/card/card";
 import { OrganizationUsersTable } from "./organization-users-table";
 import { Pagination } from "@/components/ui-kits/pagination/pagination";
 import { useGetUsers } from "@blocks-idp/iam/hooks/use-user";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import {
   OrganizationUsersFilterToolbar,
   useOrganizationUsersFilterQueryParams,

--- a/client/app/cross-modules/idp/iam/modules/organization-management/organizations/organizations.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/organizations/organizations.test.tsx
@@ -11,7 +11,7 @@ const h = vi.hoisted(() => ({
   addDisabled: undefined as unknown,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({

--- a/client/app/cross-modules/idp/iam/modules/organization-management/organizations/organizations.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/organizations/organizations.tsx
@@ -4,7 +4,7 @@ import {
   useGetOrganizations,
   useGetOrganizationConfig,
 } from "@blocks-idp/iam/hooks/use-organization";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { OrganizationsList } from "./organizations-list";
 import { AddOrganization } from "../add-organization/add-organization";
 import {

--- a/client/app/cross-modules/idp/iam/modules/organization-management/toggle-organization-status/toggle-organization-status.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/toggle-organization-status/toggle-organization-status.test.tsx
@@ -29,7 +29,7 @@ const { mutateAsync, showErrorToast, showSuccessToast } = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({
     selectedProject: { itemId: "p1", tenantId: "t1" },
   }),

--- a/client/app/cross-modules/idp/iam/modules/organization-management/toggle-organization-status/toggle-organization-status.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/toggle-organization-status/toggle-organization-status.tsx
@@ -8,7 +8,7 @@ import {
   DialogTrigger,
 } from "@/components/ui-kits/dialog/dialog";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { IOrganization } from "@blocks-idp/iam/models/organization";
 import { useSaveOrganization } from "@blocks-idp/iam/hooks/use-organization";
 type ToggleOrganizationStatusProps = {

--- a/client/app/cross-modules/idp/iam/modules/organization-management/update-organization/update-organization.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/update-organization/update-organization.test.tsx
@@ -8,7 +8,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({

--- a/client/app/cross-modules/idp/iam/modules/organization-management/update-organization/update-organization.tsx
+++ b/client/app/cross-modules/idp/iam/modules/organization-management/update-organization/update-organization.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui-kits/form/form";
 import { Input } from "@/components/ui-kits/input/input";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useSaveOrganization } from "@blocks-idp/iam/hooks/use-organization";
 import { IOrganization } from "@blocks-idp/iam/models/organization";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/client/app/cross-modules/idp/iam/modules/permission-management/add-permission/add-permission.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/add-permission/add-permission.test.tsx
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/app/proj/${p}`,
 }));
 vi.mock("@blocks-idp/iam/hooks/use-permission", () => ({

--- a/client/app/cross-modules/idp/iam/modules/permission-management/add-permission/add-permission.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/add-permission/add-permission.tsx
@@ -7,7 +7,7 @@ import { permissionFormSchemaType } from "../permission-form/utils";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { isErrorWithErrors } from "@/lib/error";
 import { useNavigate } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 export const AddPermission = () => {
   const navigate = useNavigate();
   const scoped = useScopedPath();

--- a/client/app/cross-modules/idp/iam/modules/permission-management/dependent-permissions/add-dependent-permission/add-dependent-permission.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/dependent-permissions/add-dependent-permission/add-dependent-permission.test.tsx
@@ -6,7 +6,7 @@ const h = vi.hoisted(() => ({
   useGetPermissions: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-permission", () => ({

--- a/client/app/cross-modules/idp/iam/modules/permission-management/dependent-permissions/add-dependent-permission/add-dependent-permission.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/dependent-permissions/add-dependent-permission/add-dependent-permission.tsx
@@ -21,7 +21,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui-kits/table/table";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetPermissions } from "@blocks-idp/iam/hooks/use-permission";
 import { RESOURCE_TYPE } from "@blocks-idp/iam/models/permission";
 import { useRef, useState } from "react";

--- a/client/app/cross-modules/idp/iam/modules/permission-management/permission-details/permission-roles-list.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/permission-details/permission-roles-list.test.tsx
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/scoped/${p}`,
 }));
 vi.mock("nuqs", () => ({

--- a/client/app/cross-modules/idp/iam/modules/permission-management/permission-details/permission-roles-list.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/permission-details/permission-roles-list.tsx
@@ -9,7 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui-kits/table/table";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { useGetRoles } from "@blocks-idp/iam/hooks/use-roles";
 import { IRole } from "@blocks-idp/iam/models/role";
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";

--- a/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions-group-severity.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions-group-severity.tsx
@@ -1,5 +1,5 @@
 import { useGetPermissionsGroupBySeverity } from "@blocks-idp/iam/hooks/use-permission";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 
 import { PermissionSeverity } from "@blocks-idp/iam/components/permission-severity/permission-severity";
 

--- a/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions-list.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions-list.test.tsx
@@ -34,7 +34,7 @@ vi.mock("react-router", () => ({
   ),
 }));
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (path: string) => `/scoped/${path}`,
 }));
 

--- a/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions-list.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions-list.tsx
@@ -11,7 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui-kits/table/table";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { cn } from "@/lib/utils";
 import {
   IPermission,

--- a/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   isFetching: false,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-permission", () => ({

--- a/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardHeader } from "@/components/ui-kits/card/card";
 import { Pagination } from "@/components/ui-kits/pagination/pagination";
 import { useGetPermissions } from "@blocks-idp/iam/hooks/use-permission";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { PermissionsList } from "./permissions-list";
 import {
   PermissionsFilterToolbar,

--- a/client/app/cross-modules/idp/iam/modules/role-management/roles-details/permission-selection.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/role-management/roles-details/permission-selection.test.tsx
@@ -12,7 +12,7 @@ const { getPermissions, useGetPermissions } = vi.hoisted(() => ({
 if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
 if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 

--- a/client/app/cross-modules/idp/iam/modules/role-management/roles-details/permission-selection.tsx
+++ b/client/app/cross-modules/idp/iam/modules/role-management/roles-details/permission-selection.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState, forwardRef, useImperativeHandle } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { permissionService } from "@blocks-idp/iam/services/permission.service";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import {
   Accordion,
   AccordionContent,

--- a/client/app/cross-modules/idp/iam/modules/role-management/roles-details/role-details.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/role-management/roles-details/role-details.test.tsx
@@ -20,7 +20,7 @@ const h = vi.hoisted(() => ({
   showErrorToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@/hooks/use-toast", () => ({

--- a/client/app/cross-modules/idp/iam/modules/role-management/roles-details/role-details.tsx
+++ b/client/app/cross-modules/idp/iam/modules/role-management/roles-details/role-details.tsx
@@ -2,7 +2,7 @@
 import { BREADCRUMB_CUSTOM_TITLES } from "@/constants/breadcrumb-custom-title";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import PageBreadcrumb from "@/components/breadcrumb/breadcrumb";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useSetRoles } from "@blocks-idp/iam/hooks/use-roles";
 import { Button } from "@/components/ui-kits/button/button";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";

--- a/client/app/cross-modules/idp/iam/modules/role-management/roles/roles-list.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/role-management/roles/roles-list.test.tsx
@@ -29,7 +29,7 @@ vi.mock("react-router", () => ({
   useNavigate: () => navigate,
 }));
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (path: string) => `/scoped/${path}`,
 }));
 

--- a/client/app/cross-modules/idp/iam/modules/role-management/roles/roles-list.tsx
+++ b/client/app/cross-modules/idp/iam/modules/role-management/roles/roles-list.tsx
@@ -14,7 +14,7 @@ import { Pencil } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { UpdateRole } from "../update-role/update-role";
 import { useNavigate } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 import { IRole } from "@blocks-idp/iam/models/role";
 import { FilterControls, SortValue } from "@/components/filter-toolbar";
 import { useRolesSortQueryParams } from "./roles-filter-toolbar";

--- a/client/app/cross-modules/idp/iam/modules/user-management/configure/configure.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/configure/configure.test.tsx
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-iam-configuration", () => ({

--- a/client/app/cross-modules/idp/iam/modules/user-management/configure/configure.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/configure/configure.tsx
@@ -15,7 +15,7 @@ import { iamConfigFormDefaultValues, iamConfigFormSchema } from "./utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import {
   useGetIamConfiguration,
   useSaveIamConfiguration,

--- a/client/app/cross-modules/idp/iam/modules/user-management/invite-user/invite-user.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/invite-user/invite-user.test.tsx
@@ -11,7 +11,7 @@ const h = vi.hoisted(() => ({
 vi.mock("@blocks-idp/iam/hooks/use-user", () => ({
   useAddUser: () => ({ isPending: false, mutateAsync: h.mutateAsync }),
 }));
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@/hooks/use-toast", () => ({

--- a/client/app/cross-modules/idp/iam/modules/user-management/invite-user/invite-user.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/invite-user/invite-user.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/components/ui-kits/form/form";
 import { useAddUser } from "@blocks-idp/iam/hooks/use-user";
 import { z } from "zod";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useState } from "react";
 import { isErrorWithErrors } from "@/lib/error";
 import { PrimaryButton } from "@/components/action-buttons/primary-button";

--- a/client/app/cross-modules/idp/iam/modules/user-management/signup-settings/signup-settings.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/signup-settings/signup-settings.test.tsx
@@ -7,7 +7,7 @@ const h = vi.hoisted(() => ({
   isPending: false,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-user", () => ({

--- a/client/app/cross-modules/idp/iam/modules/user-management/signup-settings/signup-settings.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/signup-settings/signup-settings.tsx
@@ -13,7 +13,7 @@ import {
 import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
 import { Wrench } from "lucide-react";
 import { useGetSignUpSetting, useSaveSignUpSetting } from "@blocks-idp/iam/hooks/use-user";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 export const SignupSettings = () => {
   const [open, setOpen] = useState(false);
   const [allowSignup, setAllowSignup] = useState(false);

--- a/client/app/cross-modules/idp/iam/modules/user-management/user-pat/user-pats-list.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/user-pat/user-pats-list.test.tsx
@@ -5,7 +5,7 @@ import type { IPATResponse } from "@blocks-idp/iam/models/user";
 
 const h = vi.hoisted(() => ({ isMobile: false }));
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({ useIsMobile: () => h.isMobile }));
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({ useIsMobile: () => h.isMobile }));
 vi.mock("./generate-pat-modal", () => ({
   GenerateTokenModal: ({ isOpen }: { isOpen: boolean }) =>
     isOpen ? <div data-testid="generate-modal" /> : null,

--- a/client/app/cross-modules/idp/iam/modules/user-management/user-pat/user-pats-list.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/user-pat/user-pats-list.tsx
@@ -15,7 +15,7 @@ import { Trash } from "lucide-react";
 import { useMemo, useState } from "react";
 import { GenerateTokenModal } from "./generate-pat-modal";
 import { CopyToClipboardButton } from "@/components/copy-to-clipboard-button/copy-to-clipboard-button";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 

--- a/client/app/cross-modules/idp/iam/modules/user-management/user-permssions/delete-user-permission/delete-user-permission.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/user-permssions/delete-user-permission/delete-user-permission.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const h = vi.hoisted(() => ({ deletePermissions: vi.fn(), isPending: false, toast: vi.fn() }));
 
 vi.mock("@/hooks/use-toast", () => ({ toast: (...a: unknown[]) => h.toast(...a) }));
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-user", () => ({

--- a/client/app/cross-modules/idp/iam/modules/user-management/user-permssions/delete-user-permission/delete-user-permission.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/user-permssions/delete-user-permission/delete-user-permission.tsx
@@ -10,7 +10,7 @@ import {
   DialogTrigger,
 } from "@/components/ui-kits/dialog/dialog";
 import { toast } from "@/hooks/use-toast";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useUserPermissions } from "@blocks-idp/iam/hooks/use-user";
 import { IPermission } from "@blocks-idp/iam/models/permission";
 import { X } from "lucide-react";

--- a/client/app/cross-modules/idp/iam/modules/user-management/users/users.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/users/users.test.tsx
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
   isFetching: false,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-user", () => ({

--- a/client/app/cross-modules/idp/iam/modules/user-management/users/users.tsx
+++ b/client/app/cross-modules/idp/iam/modules/user-management/users/users.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui-kits/card/card";
 import { UsersTable } from "./users-table";
 import { Pagination } from "@/components/ui-kits/pagination/pagination";
 import { useGetUsers } from "@blocks-idp/iam/hooks/use-user";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import {
   UsersFilterToolbar,
   useUsersFilterQueryParams,

--- a/client/app/cross-modules/idp/iam/pages/organization-detail/organization-detail.tsx
+++ b/client/app/cross-modules/idp/iam/pages/organization-detail/organization-detail.tsx
@@ -1,7 +1,7 @@
 import { BREADCRUMB_CUSTOM_TITLES } from "@/constants/breadcrumb-custom-title";
 import PageBreadcrumb from "@/components/breadcrumb/breadcrumb";
 import { useGetOrganizationById } from "@blocks-idp/iam/hooks/use-organization";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import {
   OrganizationUsers,

--- a/client/app/cross-modules/idp/iam/services/user.service.ts
+++ b/client/app/cross-modules/idp/iam/services/user.service.ts
@@ -32,7 +32,7 @@ import { UserAccountService } from "./account.service";
 import { USER_ENDPOINTS } from "../constants/endpoint.constant";
 import { mapSignUpSettingFromApi } from "../utils/normalize-tenant-config";
 import { toSignupSettingsSaveApiPayload } from "../utils/signup-settings-payload";
-import { UserDetails } from "@seliseblocks/blocks-kit";
+import { UserDetails } from "@seliseblocks/genesis-os";
 
 export class UserService {
   constructor(public account: UserAccountService) {}

--- a/client/app/cross-modules/idp/mfa/hooks/use-mfa-config.test.ts
+++ b/client/app/cross-modules/idp/mfa/hooks/use-mfa-config.test.ts
@@ -29,7 +29,7 @@ import {
 } from "./use-mfa-config";
 
 vi.mock("@blocks-idp/mfa/services/mfa.service", () => mockMfaServiceFactory());
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 describe("use-mfa-config hooks", () => {
   beforeEach(() => {

--- a/client/app/cross-modules/idp/mfa/hooks/use-mfa-config.ts
+++ b/client/app/cross-modules/idp/mfa/hooks/use-mfa-config.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { mfaService } from "../services/mfa.service";
 import { IGetUserByIdPayload } from "@blocks-idp/iam/models/user";
 

--- a/client/app/cross-modules/idp/mfa/hooks/use-resend-otp.test.ts
+++ b/client/app/cross-modules/idp/mfa/hooks/use-resend-otp.test.ts
@@ -11,7 +11,7 @@ vi.mock("./use-mfa-config", () => ({
 }));
 
 const mockReset = vi.fn();
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useCountDown: vi.fn(() => ({
     remainingTime: 300,
     reset: mockReset,

--- a/client/app/cross-modules/idp/mfa/hooks/use-resend-otp.ts
+++ b/client/app/cross-modules/idp/mfa/hooks/use-resend-otp.ts
@@ -1,4 +1,4 @@
-import { useCountDown } from "@seliseblocks/blocks-kit/hooks";
+import { useCountDown } from "@seliseblocks/genesis-os/hooks";
 import { useResendMfaOTP } from "./use-mfa-config";
 import { useCallback } from "react";
 

--- a/client/app/cross-modules/idp/settings/components/assign-signup-permissions-dialog.test.tsx
+++ b/client/app/cross-modules/idp/settings/components/assign-signup-permissions-dialog.test.tsx
@@ -6,7 +6,7 @@ const h = vi.hoisted(() => ({
   isLoading: false,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-permission", () => ({

--- a/client/app/cross-modules/idp/settings/components/assign-signup-permissions-dialog.tsx
+++ b/client/app/cross-modules/idp/settings/components/assign-signup-permissions-dialog.tsx
@@ -22,7 +22,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui-kits/table/table";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetPermissions } from "@blocks-idp/iam/hooks/use-permission";
 import { IPermission, RESOURCE_TYPE } from "@blocks-idp/iam/models/permission";
 import { CirclePlus } from "lucide-react";

--- a/client/app/cross-modules/idp/settings/components/assign-signup-roles-dialog.test.tsx
+++ b/client/app/cross-modules/idp/settings/components/assign-signup-roles-dialog.test.tsx
@@ -16,7 +16,7 @@ const h = vi.hoisted(() => ({
   lastArgs: undefined as unknown,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-idp/iam/hooks/use-roles", () => ({

--- a/client/app/cross-modules/idp/settings/components/assign-signup-roles-dialog.tsx
+++ b/client/app/cross-modules/idp/settings/components/assign-signup-roles-dialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogTrigger,
 } from "@/components/ui-kits/dialog/dialog";
 import { Pagination } from "@/components/ui-kits/pagination/pagination";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetRoles } from "@blocks-idp/iam/hooks/use-roles";
 import type { IRole } from "@blocks-idp/iam/models/role";
 import { CirclePlus } from "lucide-react";

--- a/client/app/cross-modules/idp/settings/components/signup-settings-form.test.tsx
+++ b/client/app/cross-modules/idp/settings/components/signup-settings-form.test.tsx
@@ -26,7 +26,7 @@ vi.stubGlobal(
 
 const mutateAsync = vi.fn();
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 

--- a/client/app/cross-modules/idp/settings/hooks/use-settings-config.test.ts
+++ b/client/app/cross-modules/idp/settings/hooks/use-settings-config.test.ts
@@ -12,7 +12,7 @@ import {
   useSaveSettingsSignUpSetting,
 } from "./use-settings-config";
 
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 vi.mock("@blocks-idp/settings/services/settings-config.service", () => ({
   settingsConfigService: {
     getAuthConfig: vi.fn(),

--- a/client/app/cross-modules/idp/settings/hooks/use-settings-config.ts
+++ b/client/app/cross-modules/idp/settings/hooks/use-settings-config.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { settingsConfigService } from "@blocks-idp/settings/services/settings-config.service";
 import type {
   ISettingsSaveAuthConfigPayload,

--- a/client/app/cross-modules/idp/settings/hooks/use-settings-tenant-id.test.ts
+++ b/client/app/cross-modules/idp/settings/hooks/use-settings-tenant-id.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useSettingsTenantId } from "./use-settings-tenant-id";
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: vi.fn(),
 }));
 

--- a/client/app/cross-modules/idp/settings/hooks/use-settings-tenant-id.ts
+++ b/client/app/cross-modules/idp/settings/hooks/use-settings-tenant-id.ts
@@ -1,3 +1,3 @@
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 
 export const useSettingsTenantId = () => useProjectStore().selectedProject?.tenantId ?? "";

--- a/client/app/cross-modules/idp/test-utils/__mocks__/mock-factories.ts
+++ b/client/app/cross-modules/idp/test-utils/__mocks__/mock-factories.ts
@@ -9,7 +9,7 @@
  *
  * Usage in test files (vi.mock calls must be at the top level of the test file):
  *
- *   vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+ *   vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
  *   vi.mock("@/hooks/use-toast", () => mockToastFactory());
  *   vi.mock("@/lib/http/http-client", () => mockHttpClientFactory());
  *   vi.mock("@blocks-idp/authentication/services/auth.service", () => mockAuthServiceFactory());

--- a/client/app/cross-modules/lmt/components/trace-details/trace-details.test.tsx
+++ b/client/app/cross-modules/lmt/components/trace-details/trace-details.test.tsx
@@ -18,11 +18,11 @@ const h = vi.hoisted(() => ({
 vi.mock("@/hooks/use-lmt-base-path", () => ({
   useLmtBasePath: () => "/app/lmt",
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useIsMobile: () => h.isMobile,
   usePathSegments: () => [],
 }));
-vi.mock("@seliseblocks/blocks-kit", async () => {
+vi.mock("@seliseblocks/genesis-os", async () => {
   const React = await import("react");
   const Pass = ({ children }: { children?: React.ReactNode }) =>
     React.createElement(React.Fragment, null, children);

--- a/client/app/cross-modules/lmt/components/trace-details/trace-details.tsx
+++ b/client/app/cross-modules/lmt/components/trace-details/trace-details.tsx
@@ -5,7 +5,7 @@ import { useLmtBasePath } from "@/hooks/use-lmt-base-path";
 import { Download, GitBranch, PanelRightClose, PanelRightOpen } from "lucide-react";
 import { Button } from "@/components/ui-kits/button/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui-kits/card/card";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 import { useGetTraceById } from "@blocks-lmt/hooks/use-trace";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { TracingListBreadCrumb } from "./tracing-list-breadcrum/tracing-list-breadcrum";

--- a/client/app/cross-modules/lmt/components/trace-details/tracing-insights/tracing-log.tsx
+++ b/client/app/cross-modules/lmt/components/trace-details/tracing-insights/tracing-log.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetLogs } from "@blocks-lmt/hooks/use-log";
 import {
   ColumnDef,

--- a/client/app/cross-modules/lmt/components/traces-overview/traces-overview.test.tsx
+++ b/client/app/cross-modules/lmt/components/traces-overview/traces-overview.test.tsx
@@ -13,7 +13,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => h.navigate }));
-vi.mock("@seliseblocks/blocks-kit/hooks", async (importOriginal) => {
+vi.mock("@seliseblocks/genesis-os/hooks", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,

--- a/client/app/cross-modules/lmt/components/traces-overview/traces-overview.tsx
+++ b/client/app/cross-modules/lmt/components/traces-overview/traces-overview.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/components/ui-kits/table/table";
 import { Tabs, TabsContent } from "@/components/ui-kits/tabs/tabs";
 import { LMTQueryAgentSheet } from "@blocks-ai/components/lmt-query-agent/lmt-query-agent-sheet";
-import { useIsMobile } from "@seliseblocks/blocks-kit/hooks";
+import { useIsMobile } from "@seliseblocks/genesis-os/hooks";
 import { useLmtBasePath } from "@/hooks/use-lmt-base-path";
 import { formatDate, parseDateString } from "@/lib/utils";
 import { TraceProviderSetupGuideLine } from "@blocks-lmt/components/trace-guideline/trace-provider-guideline";

--- a/client/app/cross-modules/lmt/hooks/use-log.test.ts
+++ b/client/app/cross-modules/lmt/hooks/use-log.test.ts
@@ -11,7 +11,7 @@ import { lmtService } from "../services/lmt.service";
 import { useGetLogs, useGetLiveLogs } from "./use-log";
 
 vi.mock("@blocks-lmt/services/lmt.service", () => mockLmtServiceFactory());
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 describe("use-log hooks", () => {
   beforeEach(() => {

--- a/client/app/cross-modules/lmt/hooks/use-logs.test.ts
+++ b/client/app/cross-modules/lmt/hooks/use-logs.test.ts
@@ -10,7 +10,7 @@ import { lmtService } from "../services/lmt.service";
 import { useLogs } from "./use-logs";
 
 vi.mock("@blocks-lmt/services/lmt.service", () => mockLmtServiceFactory());
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 describe("useLogs", () => {
   beforeEach(() => {

--- a/client/app/cross-modules/lmt/hooks/use-logs.ts
+++ b/client/app/cross-modules/lmt/hooks/use-logs.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { IAPIResponse } from "@/models/api-response";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import type { ILog } from "../models/log.model";
 import { lmtService } from "../services/lmt.service";
 

--- a/client/app/cross-modules/lmt/hooks/use-trace.test.ts
+++ b/client/app/cross-modules/lmt/hooks/use-trace.test.ts
@@ -13,7 +13,7 @@ import { lmtService } from "../services/lmt.service";
 import { useGetTraces, useGetTraceById } from "./use-trace";
 
 vi.mock("@blocks-lmt/services/lmt.service", () => mockLmtServiceFactory());
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 describe("use-trace hooks", () => {
   beforeEach(() => {

--- a/client/app/cross-modules/lmt/hooks/use-usage.test.ts
+++ b/client/app/cross-modules/lmt/hooks/use-usage.test.ts
@@ -13,7 +13,7 @@ import { lmtService } from "../services/lmt.service";
 import { useGetOperationalAnalytics, useGetServiceAnalytics, useUsagesMetrics } from "./use-usage";
 
 vi.mock("@blocks-lmt/services/lmt.service", () => mockLmtServiceFactory());
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 describe("use-usage hooks", () => {
   beforeEach(() => {

--- a/client/app/cross-modules/localization/hooks/use-language-manager.test.ts
+++ b/client/app/cross-modules/localization/hooks/use-language-manager.test.ts
@@ -56,7 +56,7 @@ import {
 vi.mock("@blocks-localization/services/language.manager.service", () =>
   mockLanguageServiceFactory(),
 );
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 describe("Language Manager Hooks", () => {
   beforeEach(() => {

--- a/client/app/cross-modules/localization/hooks/use-language-manager.ts
+++ b/client/app/cross-modules/localization/hooks/use-language-manager.ts
@@ -1,4 +1,4 @@
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { ExportHistoryFilters, IKeyUilmExport } from "@blocks-localization/models/language";
 import { languageManagerService } from "@blocks-localization/services/language.manager.service";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";

--- a/client/app/cross-modules/secrets/hooks/use-secrets.test.ts
+++ b/client/app/cross-modules/secrets/hooks/use-secrets.test.ts
@@ -6,7 +6,7 @@ import { secretsService } from "@/services/secrets.service";
 import { showSuccessToast, showErrorToast } from "@/hooks/use-toast";
 import { useGetSecrets, useGetSecret, useSaveSecret, useDeleteSecret } from "./use-secrets";
 
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 vi.mock("@/services/secrets.service", () => ({
   secretsService: {
     gets: vi.fn(),

--- a/client/app/cross-modules/secrets/hooks/use-secrets.ts
+++ b/client/app/cross-modules/secrets/hooks/use-secrets.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { secretsService } from "@/services/secrets.service";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import type { SaveSecretRequest } from "@/cross-modules/secrets/constants/secret-key.enum";

--- a/client/app/cross-modules/storage/hooks/use-storage-configuration.test.ts
+++ b/client/app/cross-modules/storage/hooks/use-storage-configuration.test.ts
@@ -18,7 +18,7 @@ import {
 } from "./use-storage-configuration";
 
 vi.mock("@blocks-storage/services/storage.service", () => mockStorageServiceFactory());
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 
 describe("Storage Configuration Hooks", () => {
   beforeEach(() => {
@@ -54,7 +54,7 @@ describe("Storage Configuration Hooks", () => {
     });
 
     it("should still query configurations when no project is selected", async () => {
-      const { useProjectStore } = await import("@seliseblocks/blocks-kit");
+      const { useProjectStore } = await import("@seliseblocks/genesis-os");
       vi.mocked(useProjectStore).mockReturnValueOnce({
         selectedProject: undefined,
       });

--- a/client/app/cross-modules/storage/hooks/use-storage-configuration.ts
+++ b/client/app/cross-modules/storage/hooks/use-storage-configuration.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { storageService } from "../services/storage.service";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 
 export const useGetStorageConfigurations = () => {
   return useQuery({

--- a/client/app/cross-modules/storage/pages/storage-configuration/save-storage-configuration/save-storage-configuration.test.tsx
+++ b/client/app/cross-modules/storage/pages/storage-configuration/save-storage-configuration/save-storage-configuration.test.tsx
@@ -11,7 +11,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-storage/hooks/use-storage-configuration", () => ({

--- a/client/app/cross-modules/storage/pages/storage-configuration/save-storage-configuration/save-storage-configuration.tsx
+++ b/client/app/cross-modules/storage/pages/storage-configuration/save-storage-configuration/save-storage-configuration.tsx
@@ -28,7 +28,7 @@ import {
 import { z } from "zod";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { useSaveStorageConfiguration } from "@blocks-storage/hooks/use-storage-configuration";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import {
   IStorageConfiguration,
   STORAGE_STRATEGIES,

--- a/client/app/cross-modules/utilities/components/magic-url-config-dialog/configure-magic-url-modal.test.tsx
+++ b/client/app/cross-modules/utilities/components/magic-url-config-dialog/configure-magic-url-modal.test.tsx
@@ -11,7 +11,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: h.tenantId } }),
 }));
 vi.mock("@blocks-utilities/hooks/use-magic-url-config", () => ({

--- a/client/app/cross-modules/utilities/components/magic-url-config-dialog/configure-magic-url-modal.tsx
+++ b/client/app/cross-modules/utilities/components/magic-url-config-dialog/configure-magic-url-modal.tsx
@@ -13,7 +13,7 @@ import { Label } from "@/components/ui-kits/label/label";
 import { useSaveMagicUrlConfig } from "@blocks-utilities/hooks/use-magic-url-config";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { getDefaultShortUrlBase, isValidUrl } from "@blocks-utilities/utils/url.util";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { IMagicUrlConfig } from "@blocks-utilities/models/magic-url-config.model";
 import { v4 as uuidv4 } from "uuid";
 

--- a/client/app/cross-modules/utilities/components/magic-url-dialog/magic-url-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/components/magic-url-dialog/magic-url-dialog.test.tsx
@@ -7,11 +7,11 @@ const { createMagicUrl, toast } = vi.hoisted(() => ({
   toast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 
-vi.mock("@seliseblocks/blocks-kit/store", () => ({
+vi.mock("@seliseblocks/genesis-os/store", () => ({
   useAuthStore: () => ({ user: { sub: "user-9" } }),
 }));
 

--- a/client/app/cross-modules/utilities/components/magic-url-dialog/magic-url-dialog.tsx
+++ b/client/app/cross-modules/utilities/components/magic-url-dialog/magic-url-dialog.tsx
@@ -18,9 +18,9 @@ import { CalendarIcon } from "lucide-react";
 import { formatDate } from "@/lib/utils";
 import { MagicUrl } from "@blocks-utilities/models/magic-url.model";
 import { useCreateMagicUrl } from "@blocks-utilities/hooks/use-magic-url";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { toast } from "@/hooks/use-toast";
-import { useAuthStore } from "@seliseblocks/blocks-kit/store";
+import { useAuthStore } from "@seliseblocks/genesis-os/store";
 import {
   Select,
   SelectContent,

--- a/client/app/cross-modules/utilities/pages/magic-urls/magic-urls-list.test.tsx
+++ b/client/app/cross-modules/utilities/pages/magic-urls/magic-urls-list.test.tsx
@@ -17,7 +17,7 @@ vi.mock("@blocks-utilities/hooks/use-magic-url-config", () => ({
   useDeleteMagicUrlConfig: () => ({ mutateAsync: h.deleteConfig, isPending: h.isDeleting }),
   useSaveMagicUrlConfig: () => ({ mutateAsync: h.saveConfig, isPending: h.isSaving }),
 }));
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: h.tenantId } }),
 }));
 vi.mock("@blocks-utilities/utils/url.util", () => ({

--- a/client/app/cross-modules/utilities/pages/magic-urls/magic-urls.test.tsx
+++ b/client/app/cross-modules/utilities/pages/magic-urls/magic-urls.test.tsx
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
   isFetching: false,
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-utilities/hooks/use-magic-url-config", () => ({

--- a/client/app/cross-modules/utilities/pages/magic-urls/magic-urls.tsx
+++ b/client/app/cross-modules/utilities/pages/magic-urls/magic-urls.tsx
@@ -3,7 +3,7 @@ import { ConfigsTableShell } from "@/components/configs-table-shell/configs-tabl
 import { EmptyState } from "@/components/ui-kits/empty-state";
 import { useMagicUrlsFilterQueryParams, MagicUrlsFilterToolBar } from "./magic-urls-filter-toolbar";
 import { MagicUrlsList } from "./magic-urls-list";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetMagicUrlConfigs } from "@blocks-utilities/hooks/use-magic-url-config";
 import { Link2 } from "lucide-react";
 

--- a/client/app/hooks/use-lmt-base-path.ts
+++ b/client/app/hooks/use-lmt-base-path.ts
@@ -1,6 +1,6 @@
 // The generic project-id path builder lives in blocks-kit so every app can
 // reuse it; re-exported here so blocks-os call sites keep a local import.
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 
 /**
  * The LMT section base path scoped to the active project id

--- a/client/app/hooks/use-people.test.ts
+++ b/client/app/hooks/use-people.test.ts
@@ -14,7 +14,7 @@ import {
   useTransferOwnership,
 } from "./use-people";
 
-vi.mock("@seliseblocks/blocks-kit", () => mockProjectStoreFactory());
+vi.mock("@seliseblocks/genesis-os", () => mockProjectStoreFactory());
 vi.mock("@blocks-identifier/services/people.service", () => ({
   peopleService: {
     getPeople: vi.fn(),

--- a/client/app/hooks/use-people.ts
+++ b/client/app/hooks/use-people.ts
@@ -1,4 +1,4 @@
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { peopleService } from "@blocks-identifier/services/people.service";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { GetPeopleResponse } from "@/cross-modules/identifier/models/people.model";

--- a/client/app/hooks/use-project-form.test.ts
+++ b/client/app/hooks/use-project-form.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/components/create-project/utils", () => ({
   shortGuidGenerator: () => "abcde",
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({
     setTenantGroup: h.setTenantGroup,
     setSelectedProject: h.setSelectedProject,

--- a/client/app/hooks/use-project.test.ts
+++ b/client/app/hooks/use-project.test.ts
@@ -27,7 +27,7 @@ const impersonateState = {
   impersonatedTenantId: "tenant-impersonated",
   originalTenantId: "tenant-root",
 };
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: vi.fn(() => ({
     setProjects,
     selectedProject: { itemId: "p-selected" },

--- a/client/app/hooks/use-project.ts
+++ b/client/app/hooks/use-project.ts
@@ -8,7 +8,7 @@ import {
 } from "@/models/project.model";
 import { projectService } from "@/services/project.service";
 import { projectService as crossProjectService } from "@blocks-identifier/services/project.service";
-import { useImpersonateStore, useProjectStore } from "@seliseblocks/blocks-kit";
+import { useImpersonateStore, useProjectStore } from "@seliseblocks/genesis-os";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useNavigate } from "react-router";

--- a/client/app/layouts/lmt/lmt-layout.test.tsx
+++ b/client/app/layouts/lmt/lmt-layout.test.tsx
@@ -15,7 +15,7 @@ vi.mock("react-router", () => ({
   Outlet: () => <div data-testid="outlet" />,
 }));
 vi.mock("@/hooks/use-lmt-base-path", () => ({ useLmtBasePath: () => h.basePath }));
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
 vi.mock("@blocks-lmt/hooks/use-usage", () => ({

--- a/client/app/layouts/lmt/lmt-layout.tsx
+++ b/client/app/layouts/lmt/lmt-layout.tsx
@@ -11,7 +11,7 @@ import { LMT_NAV_GROUPS } from "@/constants/lmt-nav";
 import { useLmtBasePath } from "@/hooks/use-lmt-base-path";
 import { cn } from "@/lib/utils";
 import { useUsagesMetrics } from "@blocks-lmt/hooks/use-usage";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { RefreshCcw } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 import { Outlet, useLocation } from "react-router";

--- a/client/app/layouts/project-overview-layout.tsx
+++ b/client/app/layouts/project-overview-layout.tsx
@@ -1,8 +1,8 @@
-import { DashboardHeader, SidebarMenuDesktop } from "@seliseblocks/blocks-kit/components";
-import { ImpersonationChecker, ImpersonationTerminator } from "@seliseblocks/blocks-kit/guards";
+import { DashboardHeader, SidebarMenuDesktop } from "@seliseblocks/genesis-os/components";
+import { ImpersonationChecker, ImpersonationTerminator } from "@seliseblocks/genesis-os/guards";
 import type * as React from "react";
-import type { LayoutProps } from "@seliseblocks/blocks-kit/layouts";
-import { DashboardLayoutProvider } from "@seliseblocks/blocks-kit/providers";
+import type { LayoutProps } from "@seliseblocks/genesis-os/layouts";
+import { DashboardLayoutProvider } from "@seliseblocks/genesis-os/providers";
 
 export interface ProjectOverviewLayoutProps extends LayoutProps {
   wrapper?: (content: React.ReactNode) => React.ReactNode;

--- a/client/app/layouts/project-overview-route.test.tsx
+++ b/client/app/layouts/project-overview-route.test.tsx
@@ -49,7 +49,7 @@ vi.mock("@/hooks/use-project", () => ({
 
 // Lightweight stand-in for the shared zustand store, supporting the selector
 // call form `useProjectStore((s) => s.setTenantGroup)` the source uses.
-vi.mock("@seliseblocks/blocks-kit/store", () => ({
+vi.mock("@seliseblocks/genesis-os/store", () => ({
   useAuthStore: () => ({ user: h.user }),
   useProjectStore: (selector: (s: unknown) => unknown) =>
     selector({
@@ -58,7 +58,7 @@ vi.mock("@seliseblocks/blocks-kit/store", () => ({
     }),
 }));
 
-vi.mock("@seliseblocks/blocks-kit/components", () => ({
+vi.mock("@seliseblocks/genesis-os/components", () => ({
   AppLoadingSpinner: () => <div>loading spinner</div>,
 }));
 

--- a/client/app/layouts/project-overview-route.tsx
+++ b/client/app/layouts/project-overview-route.tsx
@@ -1,11 +1,11 @@
-import { AppLoadingSpinner } from "@seliseblocks/blocks-kit/components";
-import type { LayoutProps } from "@seliseblocks/blocks-kit/layouts";
-import type { Menu } from "@seliseblocks/blocks-kit/types";
+import { AppLoadingSpinner } from "@seliseblocks/genesis-os/components";
+import type { LayoutProps } from "@seliseblocks/genesis-os/layouts";
+import type { Menu } from "@seliseblocks/genesis-os/types";
 import { useEffect } from "react";
 import { Navigate, Outlet, useParams } from "react-router";
 import { ProjectOverviewLayout } from "./project-overview-layout";
 import { useGetProjects } from "@/hooks/use-project";
-import { useAuthStore, useProjectStore } from "@seliseblocks/blocks-kit/store";
+import { useAuthStore, useProjectStore } from "@seliseblocks/genesis-os/store";
 
 export type ProjectOverviewRouteProps = LayoutProps & {
   /** Base path the project-overview routes live under. */

--- a/client/app/lib/http/http-client.ts
+++ b/client/app/lib/http/http-client.ts
@@ -1,5 +1,5 @@
 import { getRuntimeEnv } from "@/lib/runtime-env";
-import { HttpClient } from "@seliseblocks/blocks-kit/lib";
+import { HttpClient } from "@seliseblocks/genesis-os/lib";
 
 export const http = new HttpClient({
   baseURL: getRuntimeEnv("BLOCKS_OS_BASE_URL") || "",

--- a/client/app/main.tsx
+++ b/client/app/main.tsx
@@ -1,4 +1,4 @@
-import "@seliseblocks/blocks-kit/lib";
+import "@seliseblocks/genesis-os/lib";
 import "@/styles/globals.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -8,7 +8,7 @@ import { Toaster } from "./components/ui-kits/toaster/toaster";
 import { TooltipProvider } from "./components/ui-kits/tooltip/tooltip";
 import QueryProvider from "./providers/query-provider";
 import { router } from "./router";
-import { BlocksAppLayout, ThemeProvider } from "@seliseblocks/blocks-kit/providers";
+import { BlocksAppLayout, ThemeProvider } from "@seliseblocks/genesis-os/providers";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/client/app/models/project.model.ts
+++ b/client/app/models/project.model.ts
@@ -1,5 +1,5 @@
 import { DomainAction } from "@/pages/dashboard/components/domain";
-import { IProject, IDomain } from "@seliseblocks/blocks-kit/models";
+import { IProject, IDomain } from "@seliseblocks/genesis-os/models";
 
 export interface IProjectGroup {
   tenantGroupId: string;

--- a/client/app/pages/dashboard/components/cname/dialog.tsx
+++ b/client/app/pages/dashboard/components/cname/dialog.tsx
@@ -5,7 +5,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui-kits/dialog/dialog";
-import type { IDomain } from "@seliseblocks/blocks-kit/models";
+import type { IDomain } from "@seliseblocks/genesis-os/models";
 import { CheckCircle2 } from "lucide-react";
 import { CNameInstruction } from "./instructions";
 import { CnameValidatorProject } from "./validator-project";

--- a/client/app/pages/dashboard/components/cname/validator-project.test.tsx
+++ b/client/app/pages/dashboard/components/cname/validator-project.test.tsx
@@ -7,11 +7,11 @@ const h = vi.hoisted(() => ({ mutateAsync: vi.fn(), isPending: false, ok: vi.fn(
 vi.mock("@/hooks/use-project", () => ({
   useValidateCNameProject: () => ({ mutateAsync: h.mutateAsync, isPending: h.isPending }),
 }));
-vi.mock("@seliseblocks/blocks-kit/utils", () => ({
+vi.mock("@seliseblocks/genesis-os/utils", () => ({
   showSuccessToast: (...a: unknown[]) => h.ok(...a),
   showErrorToast: (...a: unknown[]) => h.err(...a),
 }));
-vi.mock("@seliseblocks/blocks-kit/components", () => ({
+vi.mock("@seliseblocks/genesis-os/components", () => ({
   LoadingButton: ({
     children,
     onClick,

--- a/client/app/pages/dashboard/components/cname/validator-project.tsx
+++ b/client/app/pages/dashboard/components/cname/validator-project.tsx
@@ -1,6 +1,6 @@
-import { LoadingButton } from "@seliseblocks/blocks-kit/components";
+import { LoadingButton } from "@seliseblocks/genesis-os/components";
 import { useValidateCNameProject } from "@/hooks/use-project";
-import { showErrorToast, showSuccessToast } from "@seliseblocks/blocks-kit/utils";
+import { showErrorToast, showSuccessToast } from "@seliseblocks/genesis-os/utils";
 
 interface CnameValidatorProjectProps {
   isDomainVerified: boolean;

--- a/client/app/pages/dashboard/components/custom-domain/dialog.test.tsx
+++ b/client/app/pages/dashboard/components/custom-domain/dialog.test.tsx
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => ({
 vi.mock("@/hooks/use-project", () => ({
   useUpdateRepositories: () => ({ mutateAsync: h.mutateAsync, isPending: h.isPending }),
 }));
-vi.mock("@seliseblocks/blocks-kit/utils", () => ({
+vi.mock("@seliseblocks/genesis-os/utils", () => ({
   showErrorToast: (...a: unknown[]) => h.showErrorToast(...a),
   showSuccessToast: (...a: unknown[]) => h.showSuccessToast(...a),
 }));

--- a/client/app/pages/dashboard/components/custom-domain/dialog.tsx
+++ b/client/app/pages/dashboard/components/custom-domain/dialog.tsx
@@ -6,8 +6,8 @@ import {
   DialogTitle,
 } from "@/components/ui-kits/dialog/dialog";
 import { useUpdateRepositories } from "@/hooks/use-project";
-import type { IDomain, IEnvRepository } from "@seliseblocks/blocks-kit/models";
-import { showErrorToast, showSuccessToast } from "@seliseblocks/blocks-kit/utils";
+import type { IDomain, IEnvRepository } from "@seliseblocks/genesis-os/models";
+import { showErrorToast, showSuccessToast } from "@seliseblocks/genesis-os/utils";
 import { useMemo } from "react";
 import { SetCustomDomainForm } from "./form";
 

--- a/client/app/pages/dashboard/components/domain/domain-form-dialog.tsx
+++ b/client/app/pages/dashboard/components/domain/domain-form-dialog.tsx
@@ -5,7 +5,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui-kits/dialog/dialog";
-import type { IDomain } from "@seliseblocks/blocks-kit/models";
+import type { IDomain } from "@seliseblocks/genesis-os/models";
 import { DomainForm } from "./domain-form";
 
 interface DomainFormDialogProps {

--- a/client/app/pages/dashboard/components/domain/domain-form.test.tsx
+++ b/client/app/pages/dashboard/components/domain/domain-form.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { IDomain } from "@seliseblocks/blocks-kit/models";
+import type { IDomain } from "@seliseblocks/genesis-os/models";
 
 const h = vi.hoisted(() => ({
   mutateAsync: vi.fn(),
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => ({
 vi.mock("@/hooks/use-project", () => ({
   useUpdateProject: () => ({ mutateAsync: h.mutateAsync, isPending: false }),
 }));
-vi.mock("@seliseblocks/blocks-kit/utils", () => ({
+vi.mock("@seliseblocks/genesis-os/utils", () => ({
   showSuccessToast: (...a: unknown[]) => h.showSuccessToast(...a),
   showErrorToast: (...a: unknown[]) => h.showErrorToast(...a),
 }));

--- a/client/app/pages/dashboard/components/domain/domain-form.tsx
+++ b/client/app/pages/dashboard/components/domain/domain-form.tsx
@@ -10,7 +10,7 @@ import { Input } from "@/components/ui-kits/input/input";
 import { Button } from "@/components/ui-kits/button/button";
 import { DialogClose, DialogFooter } from "@/components/ui-kits/dialog/dialog";
 import { useUpdateProject } from "@/hooks/use-project";
-import type { IDomain } from "@seliseblocks/blocks-kit/models";
+import type { IDomain } from "@seliseblocks/genesis-os/models";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import {
@@ -19,7 +19,7 @@ import {
   type DomainFormSchema,
 } from "./domain-form.schema";
 import { DomainAction } from "./domain.constant";
-import { showErrorToast, showSuccessToast } from "@seliseblocks/blocks-kit/utils";
+import { showErrorToast, showSuccessToast } from "@seliseblocks/genesis-os/utils";
 
 const getCookieDomain = (domain: string) => {
   try {

--- a/client/app/pages/dashboard/components/domain/domain-section.tsx
+++ b/client/app/pages/dashboard/components/domain/domain-section.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui-kits/button/button";
-import { DashboardSectionCard } from "@seliseblocks/blocks-kit/components";
+import { DashboardSectionCard } from "@seliseblocks/genesis-os/components";
 import { DomainFormDialog } from "./domain-form-dialog";
 import { DomainTable } from "./domain-table";
-import type { IDomain } from "@seliseblocks/blocks-kit/models";
+import type { IDomain } from "@seliseblocks/genesis-os/models";
 
 interface DomainsSectionProps {
   applications: IDomain[];

--- a/client/app/pages/dashboard/components/domain/domain-table.test.tsx
+++ b/client/app/pages/dashboard/components/domain/domain-table.test.tsx
@@ -11,8 +11,8 @@ const { mutateAsync, showErrorToast, showSuccessToast } = vi.hoisted(() => ({
 vi.mock("@/hooks/use-project", () => ({
   useUpdateProject: () => ({ mutateAsync, isPending: false }),
 }));
-vi.mock("@seliseblocks/blocks-kit/utils", () => ({ showErrorToast, showSuccessToast }));
-vi.mock("@seliseblocks/blocks-kit/components", () => ({
+vi.mock("@seliseblocks/genesis-os/utils", () => ({ showErrorToast, showSuccessToast }));
+vi.mock("@seliseblocks/genesis-os/components", () => ({
   Button: ({ children, ...props }: React.ComponentProps<"button">) => (
     <button type="button" {...props}>
       {children}
@@ -34,7 +34,7 @@ vi.mock("../cname/dialog", () => ({
 }));
 
 import { DomainTable } from "./domain-table";
-import type { IDomain } from "@seliseblocks/blocks-kit/models";
+import type { IDomain } from "@seliseblocks/genesis-os/models";
 
 const domains = [
   { domain: "verified.com", isDomainVerified: true, cookieDomain: ".verified.com" },

--- a/client/app/pages/dashboard/components/domain/domain-table.tsx
+++ b/client/app/pages/dashboard/components/domain/domain-table.tsx
@@ -1,6 +1,6 @@
 import { useUpdateProject } from "@/hooks/use-project";
 import { cn } from "@/lib/utils";
-import type { IDomain } from "@seliseblocks/blocks-kit/models";
+import type { IDomain } from "@seliseblocks/genesis-os/models";
 import {
   createColumnHelper,
   flexRender,
@@ -11,13 +11,13 @@ import { Settings, ShieldCheck, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { DomainFormDialog } from "./domain-form-dialog";
 import { DomainAction } from "./domain.constant";
-import { showErrorToast, showSuccessToast } from "@seliseblocks/blocks-kit/utils";
+import { showErrorToast, showSuccessToast } from "@seliseblocks/genesis-os/utils";
 import { CnameValidatorDialog } from "../cname/dialog";
 import {
   Button,
   CopyToClipboardButton,
   RenderConditionally,
-} from "@seliseblocks/blocks-kit/components";
+} from "@seliseblocks/genesis-os/components";
 import { Dialog } from "@/components/ui-kits/dialog/dialog";
 import { ConfirmationModal } from "@/components/confirmation-modal/confirmation-modal";
 

--- a/client/app/pages/dashboard/components/project/actions.test.tsx
+++ b/client/app/pages/dashboard/components/project/actions.test.tsx
@@ -4,11 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const h = vi.hoisted(() => ({ user: { sub: "user-1" } as { sub: string } | undefined }));
 
 vi.mock("./archive", () => ({ ArchiveProject: () => <div data-testid="archive" /> }));
-vi.mock("@seliseblocks/blocks-kit/components", () => ({
+vi.mock("@seliseblocks/genesis-os/components", () => ({
   RenderConditionally: ({ condition, children }: { condition: boolean; children: React.ReactNode }) =>
     condition ? <>{children}</> : null,
 }));
-vi.mock("@seliseblocks/blocks-kit/store", () => ({ useAuthStore: () => ({ user: h.user }) }));
+vi.mock("@seliseblocks/genesis-os/store", () => ({ useAuthStore: () => ({ user: h.user }) }));
 
 import { ProjectActions } from "./actions";
 

--- a/client/app/pages/dashboard/components/project/actions.tsx
+++ b/client/app/pages/dashboard/components/project/actions.tsx
@@ -1,7 +1,7 @@
 import { ArchiveProject } from "./archive";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
-import { RenderConditionally } from "@seliseblocks/blocks-kit/components";
-import { useAuthStore } from "@seliseblocks/blocks-kit/store";
+import { RenderConditionally } from "@seliseblocks/genesis-os/components";
+import { useAuthStore } from "@seliseblocks/genesis-os/store";
 
 type ProjectActionsProps = {
   itemId: string;

--- a/client/app/pages/dashboard/components/project/archive.test.tsx
+++ b/client/app/pages/dashboard/components/project/archive.test.tsx
@@ -16,10 +16,10 @@ const h = vi.hoisted(() => ({
 vi.mock("@/hooks/use-project", () => ({
   useDisableProject: () => ({ mutateAsync: h.mutateAsync, isPending: h.isPending }),
 }));
-vi.mock("@seliseblocks/blocks-kit/store", () => ({
+vi.mock("@seliseblocks/genesis-os/store", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
-vi.mock("@seliseblocks/blocks-kit/utils", () => ({
+vi.mock("@seliseblocks/genesis-os/utils", () => ({
   showSuccessToast: (...a: unknown[]) => h.showSuccessToast(...a),
   showErrorToast: (...a: unknown[]) => h.showErrorToast(...a),
   isErrorWithErrors: (e: unknown) => h.isErrorWithErrors(e),

--- a/client/app/pages/dashboard/components/project/archive.tsx
+++ b/client/app/pages/dashboard/components/project/archive.tsx
@@ -1,11 +1,11 @@
 import { Dialog, DialogTrigger } from "@/components/ui-kits/dialog/dialog";
 import { useDisableProject } from "@/hooks/use-project";
-import { isErrorWithErrors } from "@seliseblocks/blocks-kit/utils";
-import { useProjectStore } from "@seliseblocks/blocks-kit/store";
+import { isErrorWithErrors } from "@seliseblocks/genesis-os/utils";
+import { useProjectStore } from "@seliseblocks/genesis-os/store";
 import { Archive } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import { showErrorToast, showSuccessToast } from "@seliseblocks/blocks-kit/utils";
+import { showErrorToast, showSuccessToast } from "@seliseblocks/genesis-os/utils";
 import { Button } from "@/components/ui-kits/button/button";
 import { ConfirmationModal } from "@/components/confirmation-modal/confirmation-modal";
 

--- a/client/app/pages/dashboard/components/project/edit/edit-project-form.test.tsx
+++ b/client/app/pages/dashboard/components/project/edit/edit-project-form.test.tsx
@@ -14,7 +14,7 @@ const h = vi.hoisted(() => ({
 vi.mock("@/hooks/use-project", () => ({
   useUpdateTenantGroup: () => ({ mutateAsync: h.mutateAsync, isPending: h.isPending }),
 }));
-vi.mock("@seliseblocks/blocks-kit/utils", () => ({
+vi.mock("@seliseblocks/genesis-os/utils", () => ({
   showSuccessToast: (...a: unknown[]) => h.showSuccessToast(...a),
   showErrorToast: (...a: unknown[]) => h.showErrorToast(...a),
   isErrorWithErrors: (e: unknown) => typeof e === "object" && e !== null && "errors" in e,

--- a/client/app/pages/dashboard/components/project/edit/edit-project-form.tsx
+++ b/client/app/pages/dashboard/components/project/edit/edit-project-form.tsx
@@ -21,7 +21,7 @@ import {
   showErrorToast,
   showSuccessToast,
   isErrorWithErrors,
-} from "@seliseblocks/blocks-kit/utils";
+} from "@seliseblocks/genesis-os/utils";
 import { useQueryClient } from "@tanstack/react-query";
 
 interface EditProjectFormProps {

--- a/client/app/pages/dashboard/components/project/edit/edit-project.tsx
+++ b/client/app/pages/dashboard/components/project/edit/edit-project.tsx
@@ -3,7 +3,7 @@ import { Edit } from "lucide-react";
 import { Button } from "@/components/ui-kits/button/button";
 import { EditProjectDialog } from "./edit-project-dialog";
 import { useState } from "react";
-import { useProjectStore } from "@seliseblocks/blocks-kit/store";
+import { useProjectStore } from "@seliseblocks/genesis-os/store";
 
 export function EditProject() {
   const [openEditDialog, setOpenEditDialog] = useState(false);

--- a/client/app/pages/dashboard/components/project/overview.tsx
+++ b/client/app/pages/dashboard/components/project/overview.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui-kits/badge/badge";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
-import { CopyToClipboardButton, MaskedText } from "@seliseblocks/blocks-kit/components";
+import { CopyToClipboardButton, MaskedText } from "@seliseblocks/genesis-os/components";
 
 type ProjectOverviewProps = {
   name: string;

--- a/client/app/pages/dashboard/components/project/repo-list.tsx
+++ b/client/app/pages/dashboard/components/project/repo-list.tsx
@@ -1,7 +1,7 @@
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
-import { DashboardSectionCard } from "@seliseblocks/blocks-kit/components";
+import { DashboardSectionCard } from "@seliseblocks/genesis-os/components";
 import { useGetEnvRepositories } from "@/hooks/use-project";
-import type { IProject } from "@seliseblocks/blocks-kit/models";
+import type { IProject } from "@seliseblocks/genesis-os/models";
 import { ProjectRepoTable } from "./repo-table";
 
 export const ProjectRepoList = ({

--- a/client/app/pages/dashboard/components/project/repo-table.test.tsx
+++ b/client/app/pages/dashboard/components/project/repo-table.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { IEnvRepository } from "@seliseblocks/blocks-kit/models";
+import type { IEnvRepository } from "@seliseblocks/genesis-os/models";
 
-vi.mock("@seliseblocks/blocks-kit/utils", () => ({
+vi.mock("@seliseblocks/genesis-os/utils", () => ({
   formatFullDate: () => "FMT-DATE",
 }));
 

--- a/client/app/pages/dashboard/components/project/repo-table.tsx
+++ b/client/app/pages/dashboard/components/project/repo-table.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui-kits/button/button";
 import { cn } from "@/lib/utils";
-import type { IDomain, IEnvRepository } from "@seliseblocks/blocks-kit/models";
-import { formatFullDate } from "@seliseblocks/blocks-kit/utils";
+import type { IDomain, IEnvRepository } from "@seliseblocks/genesis-os/models";
+import { formatFullDate } from "@seliseblocks/genesis-os/utils";
 import {
   createColumnHelper,
   flexRender,

--- a/client/app/pages/environments/environments.test.tsx
+++ b/client/app/pages/environments/environments.test.tsx
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   notificationListener: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => {
+vi.mock("@seliseblocks/genesis-os", () => {
   const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
   return {
     useProjectStore: () => ({ selectedTenantGroup: h.selectedTenantGroup }),

--- a/client/app/pages/environments/environments.tsx
+++ b/client/app/pages/environments/environments.tsx
@@ -21,7 +21,7 @@ import { useNotificationListener } from "@/cross-modules/communication/hooks/use
 import { useGetPeople } from "@/hooks/use-people";
 import { useGetMigrationStatus, useGetProjects } from "@/hooks/use-project";
 import type { IMigrationStatusResponse } from "@blocks-identifier/models/project.model";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { CircleHelp, Plus } from "lucide-react";
 import { useCallback, useState } from "react";
 

--- a/client/app/pages/lmt/tracing.tsx
+++ b/client/app/pages/lmt/tracing.tsx
@@ -1,5 +1,5 @@
 import { TracesOverview } from "@/cross-modules/lmt/components/traces-overview/traces-overview";
-import { Card, CardContent, useProjectStore } from "@seliseblocks/blocks-kit";
+import { Card, CardContent, useProjectStore } from "@seliseblocks/genesis-os";
 
 // tracing-route.tsx
 export function TracingRoute() {

--- a/client/app/pages/lmt/usage.tsx
+++ b/client/app/pages/lmt/usage.tsx
@@ -13,7 +13,7 @@ import {
   CardHeader,
   CardTitle,
   useProjectStore,
-} from "@seliseblocks/blocks-kit";
+} from "@seliseblocks/genesis-os";
 import { Network, Clock, CircleCheck, CircleAlert } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 

--- a/client/app/pages/people/invite-people.test.tsx
+++ b/client/app/pages/people/invite-people.test.tsx
@@ -12,11 +12,11 @@ const { mutateAsync, showErrorToast, showSuccessToast, useGetProjects } = vi.hoi
 if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
 if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedTenantGroup: "group-1" }),
 }));
 
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   usePopoverWidth: () => [{ current: null }, 200],
   useIsMobile: () => false,
 }));

--- a/client/app/pages/people/invite-people.tsx
+++ b/client/app/pages/people/invite-people.tsx
@@ -29,7 +29,7 @@ import {
   FormMessage,
 } from "@/components/ui-kits/form/form";
 import { Input } from "@/components/ui-kits/input/input";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useInvitePeople } from "@/hooks/use-people";
 import { useGetProjects } from "@/hooks/use-project";
 import { MultiSelect } from "@/components/filter-toolbar/multi-select/multi-select";

--- a/client/app/pages/people/people-environments-tab.test.tsx
+++ b/client/app/pages/people/people-environments-tab.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/hooks/use-toast", () => ({
   showSuccessToast: (...args: unknown[]) => showSuccessToast(...args),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: Object.assign(
     () => ({ selectedTenantGroup: "group-1" }),
     { getState: () => ({ selectedTenantGroup: "group-1" }) },

--- a/client/app/pages/people/people-environments-tab.tsx
+++ b/client/app/pages/people/people-environments-tab.tsx
@@ -11,7 +11,7 @@ import { ConfirmationModal } from "@/components/confirmation-modal/confirmation-
 import { PeopleGroupedByEnvironments } from "@/models/people";
 import { IProjectGroup } from "@/models/project.model";
 import { environmentOptions } from "@/constants/environment-options";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { buildInvitePeoplePayload } from "./invite-people-utils";
 
 interface PeopleEnvironmentsTabProps {

--- a/client/app/pages/people/people-table.test.tsx
+++ b/client/app/pages/people/people-table.test.tsx
@@ -52,7 +52,7 @@ vi.mock("@blocks-idp/iam/hooks/use-account", () => ({
   useAccountResendActivation: () => ({ mutateAsync: h.resendActivation }),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => {
+vi.mock("@seliseblocks/genesis-os", () => {
   const store = () => ({ selectedTenantGroup: "grp-1" });
   (store as unknown as { getState: () => unknown }).getState = () => ({
     selectedTenantGroup: "grp-1",

--- a/client/app/pages/people/people-table.tsx
+++ b/client/app/pages/people/people-table.tsx
@@ -37,7 +37,7 @@ import { useRemoveAccess, useResendInvitation, useTransferOwnership } from "@/ho
 import { useAccountResendActivation } from "@blocks-idp/iam/hooks/use-account";
 import { useNavigate, useParams } from "react-router";
 import { PeopleGroupedByEnvironments } from "@/models/people";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { environmentOptions } from "@/constants/environment-options";
 import { Badge } from "@/components/ui-kits/badge/badge";
 import { PeopleStatusBadge } from "@/components/people/status-badge";

--- a/client/app/pages/people/person-detail-page.test.tsx
+++ b/client/app/pages/people/person-detail-page.test.tsx
@@ -19,7 +19,7 @@ vi.mock("react-router", async () => {
   const actual = await vi.importActual<typeof import("react-router")>("react-router");
   return { ...actual, useNavigate: () => h.navigate, useParams: () => h.params };
 });
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedTenantGroup: "tg-1" }),
 }));
 vi.mock("nuqs", () => {

--- a/client/app/pages/people/person-detail-page.tsx
+++ b/client/app/pages/people/person-detail-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { PeopleDetailsTab } from "./people-details-tab";
 import { PeopleEnvironmentsTab } from "./people-environments-tab";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui-kits/tabs/tabs";

--- a/client/app/pages/repositories/repositories.test.tsx
+++ b/client/app/pages/repositories/repositories.test.tsx
@@ -11,10 +11,10 @@ const h = vi.hoisted(() => ({
   toast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedTenantGroup: h.selectedTenantGroup }),
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useDebounce: (value: unknown) => value,
 }));
 vi.mock("@/hooks/use-toast", () => ({ toast: h.toast }));

--- a/client/app/pages/repositories/repositories.tsx
+++ b/client/app/pages/repositories/repositories.tsx
@@ -1,4 +1,4 @@
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useGetAssets, useAddAssets } from "@/hooks/use-project";
 import { Plus, Github, FolderGit2 } from "lucide-react";
 import { EmptyState } from "@/components/ui-kits/empty-state";
@@ -27,7 +27,7 @@ import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { Input } from "@/components/ui-kits/input/input";
 import { IResource } from "@blocks-identifier/models/project.model";
 import { IRepository } from "@/cross-modules/devops/models/github-info";
-import { useDebounce } from "@seliseblocks/blocks-kit/hooks";
+import { useDebounce } from "@seliseblocks/genesis-os/hooks";
 import { useValidateAuthorization } from "@/cross-modules/devops/hooks/github-info";
 import { RepositorySelectionModal } from "@/components/repository-selection-modal/repository-selection-modal";
 import ProviderButtons from "@/cross-modules/devops/components/deployment-steps/render-repos/render-provider";

--- a/client/app/pages/settings/settings.test.tsx
+++ b/client/app/pages/settings/settings.test.tsx
@@ -13,7 +13,7 @@ const h = vi.hoisted(() => ({
   toast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({
     selectedProject: h.selectedProject,
     selectedTenantGroup: h.selectedTenantGroup,

--- a/client/app/pages/settings/settings.tsx
+++ b/client/app/pages/settings/settings.tsx
@@ -24,7 +24,7 @@ import {
   FormMessage,
 } from "@/components/ui-kits/form/form";
 import { useGetProjects, useUpdateTenantGroup } from "@/hooks/use-project";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { formatDate } from "@/lib/utils";
 import { EnvironmentsCard, getEnvironmentOrder } from "./environments-card";
 const SettingsLoading = () => (

--- a/client/app/router.tsx
+++ b/client/app/router.tsx
@@ -1,6 +1,6 @@
-import { AuthResolver, ProtectedGuard, PublicGuard } from "@seliseblocks/blocks-kit/guards";
-import { ConsoleLayout, DashboardRoute } from "@seliseblocks/blocks-kit/layouts";
-import { CallbackPage, ConsolePage, LoginPage, ProfilePage } from "@seliseblocks/blocks-kit/pages";
+import { AuthResolver, ProtectedGuard, PublicGuard } from "@seliseblocks/genesis-os/guards";
+import { ConsoleLayout, DashboardRoute } from "@seliseblocks/genesis-os/layouts";
+import { CallbackPage, ConsolePage, LoginPage, ProfilePage } from "@seliseblocks/genesis-os/pages";
 import { createBrowserRouter, Navigate, Outlet, useParams } from "react-router";
 import { navigationMenus } from "./constants/navigation-menus";
 // Temporarily disabled

--- a/client/app/routes/auth/sso-callback.test.tsx
+++ b/client/app/routes/auth/sso-callback.test.tsx
@@ -23,7 +23,7 @@ vi.stubGlobal(
 );
 
 const h = vi.hoisted(() => ({ setAuthenticated: vi.fn() }));
-vi.mock("@seliseblocks/blocks-kit/store", () => ({
+vi.mock("@seliseblocks/genesis-os/store", () => ({
   useAuthStore: () => ({ setAuthenticated: h.setAuthenticated }),
 }));
 const setAuthenticated = h.setAuthenticated;

--- a/client/app/routes/auth/sso-callback.tsx
+++ b/client/app/routes/auth/sso-callback.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useSearchParams } from "react-router";
-import { useAuthStore } from "@seliseblocks/blocks-kit/store";
+import { useAuthStore } from "@seliseblocks/genesis-os/store";
 import { getRuntimeEnv } from "@/lib/runtime-env";
 import LogoLoadingSpinner from "@/components/loader-spinner/loader-spinner";
 

--- a/client/app/routes/dashboard/api-settings.interactions.test.tsx
+++ b/client/app/routes/dashboard/api-settings.interactions.test.tsx
@@ -16,7 +16,7 @@ const h = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: h.tenantId } }),
 }));
 vi.mock("@blocks-idp/api-settings/hooks/use-api-settings", () => ({

--- a/client/app/routes/dashboard/api-settings.test.tsx
+++ b/client/app/routes/dashboard/api-settings.test.tsx
@@ -31,7 +31,7 @@ const h = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "t-1" } }),
 }));
 

--- a/client/app/routes/dashboard/api-settings.tsx
+++ b/client/app/routes/dashboard/api-settings.tsx
@@ -10,7 +10,7 @@ import {
 } from "@blocks-idp/api-settings/hooks/use-api-settings";
 import { IApiEndpoint } from "@blocks-idp/api-settings/models/api-endpoint.model";
 import { getServiceSwaggerUrl } from "@blocks-idp/api-settings/utils/service-swagger";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { BookOpen, ExternalLink } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 /** ─── Loading skeleton ──────────────────────────────────────────────────────── */

--- a/client/app/routes/dashboard/secret-management.test.tsx
+++ b/client/app/routes/dashboard/secret-management.test.tsx
@@ -15,10 +15,10 @@ vi.mock("react-router", () => ({
   useLocation: () => ({ pathname: h.pathname }),
   Outlet: () => <div data-testid="outlet" />,
 }));
-vi.mock("@seliseblocks/blocks-kit", () => ({
+vi.mock("@seliseblocks/genesis-os", () => ({
   useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
 }));
-vi.mock("@seliseblocks/blocks-kit/hooks", () => ({
+vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (p: string) => `/app/proj/${p}`,
 }));
 vi.mock("@blocks-idp/captcha/hooks/use-captcha-config", () => ({

--- a/client/app/routes/dashboard/secret-management.tsx
+++ b/client/app/routes/dashboard/secret-management.tsx
@@ -20,12 +20,12 @@ import {
   useOidcBrandingHeaderOptional,
 } from "@blocks-idp/authentication/contexts/oidc-branding-header-context";
 import { PrimaryButton } from "@/components/action-buttons/primary-button";
-import { useProjectStore } from "@seliseblocks/blocks-kit";
+import { useProjectStore } from "@seliseblocks/genesis-os";
 import { Pencil, Plus, Loader2, Notebook, Waypoints } from "lucide-react";
 import { parseAsBoolean, parseAsString, useQueryState } from "nuqs";
 import { MouseEvent, useMemo } from "react";
 import { Outlet, useLocation } from "react-router";
-import { useScopedPath } from "@seliseblocks/blocks-kit/hooks";
+import { useScopedPath } from "@seliseblocks/genesis-os/hooks";
 
 function SecretManagementHeaderActions({
   isOidcBranding,

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -34,7 +34,7 @@
         "@radix-ui/react-tabs": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.2",
-        "@seliseblocks/blocks-kit": "0.0.71",
+        "@seliseblocks/genesis-os": "^4.0.0",
         "@tanstack/react-query": "^5.62.11",
         "@tanstack/react-query-devtools": "^5.62.11",
         "@tanstack/react-table": "^8.20.5",
@@ -2871,43 +2871,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
-      "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "1.0.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-escape-keydown/node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
-      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-use-is-hydrated": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
@@ -3375,10 +3338,10 @@
         "win32"
       ]
     },
-    "node_modules/@seliseblocks/blocks-kit": {
-      "version": "0.0.71",
-      "resolved": "https://registry.npmjs.org/@seliseblocks/blocks-kit/-/blocks-kit-0.0.71.tgz",
-      "integrity": "sha512-QBOg0EXzr2W5C1TqO3AeDUByxkHxjwIxHDIg9jLW6dpa2zB5Vu362FlzwYpwB/iqJjAi5uaCSUK3tyPTjmcvSw==",
+    "node_modules/@seliseblocks/genesis-os": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@seliseblocks/genesis-os/-/genesis-os-4.0.0.tgz",
+      "integrity": "sha512-XHkjk/LU7A4wxKTfOgzZMJhNWRWebJux661nYLUQ/LsmX/gwBGwYC2QduND3uCHpdG8Y3GnaD0zHKaFSl8K1+Q==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -3449,7 +3412,7 @@
         }
       }
     },
-    "node_modules/@seliseblocks/blocks-kit/node_modules/@hookform/resolvers": {
+    "node_modules/@seliseblocks/genesis-os/node_modules/@hookform/resolvers": {
       "version": "5.5.7",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.5.7.tgz",
       "integrity": "sha512-CyPCYV8/KlXfEXLWj8HHHhVsR/IZ6Ckm3b/a4fWtO/lRnRK1huqncb8LlAWrmpPRsse5glF5aVuDRMHEr3UGag==",
@@ -3559,7 +3522,7 @@
         }
       }
     },
-    "node_modules/@seliseblocks/blocks-kit/node_modules/ajv": {
+    "node_modules/@seliseblocks/genesis-os/node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
@@ -3577,7 +3540,7 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@seliseblocks/blocks-kit/node_modules/cmdk": {
+    "node_modules/@seliseblocks/genesis-os/node_modules/cmdk": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
       "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
@@ -3593,7 +3556,7 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/@seliseblocks/blocks-kit/node_modules/date-fns": {
+    "node_modules/@seliseblocks/genesis-os/node_modules/date-fns": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
       "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
@@ -3603,7 +3566,7 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
-    "node_modules/@seliseblocks/blocks-kit/node_modules/file-selector": {
+    "node_modules/@seliseblocks/genesis-os/node_modules/file-selector": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-4.0.2.tgz",
       "integrity": "sha512-gG5a3fIH+jVZY3AZeupJBjYnRd65YUTCO26gKhfE24LvmGPmBAx0peyxrjUkX6PhKfTUl9UPi7UYwvDS6RI2Jg==",
@@ -3612,7 +3575,7 @@
         "node": ">= 20"
       }
     },
-    "node_modules/@seliseblocks/blocks-kit/node_modules/json-schema-traverse": {
+    "node_modules/@seliseblocks/genesis-os/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
@@ -3620,7 +3583,7 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/@seliseblocks/blocks-kit/node_modules/lucide-react": {
+    "node_modules/@seliseblocks/genesis-os/node_modules/lucide-react": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.27.0.tgz",
       "integrity": "sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==",
@@ -3629,7 +3592,7 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@seliseblocks/blocks-kit/node_modules/react-dropzone": {
+    "node_modules/@seliseblocks/genesis-os/node_modules/react-dropzone": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-19.1.1.tgz",
       "integrity": "sha512-zxuTwbyvP+FSdesiHafT/0UMTX/Ne1ri8XPTn7KM97ZinHKFy3N6KiKEGRiG28ibYV+nG6sHxoJlkVoDxIMHxQ==",
@@ -3651,7 +3614,7 @@
         }
       }
     },
-    "node_modules/@seliseblocks/blocks-kit/node_modules/tailwind-merge": {
+    "node_modules/@seliseblocks/genesis-os/node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
       "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",

--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,7 @@
     "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.2",
-    "@seliseblocks/blocks-kit": "0.0.71",
+    "@seliseblocks/genesis-os": "^4.0.0",
     "@tanstack/react-query": "^5.62.11",
     "@tanstack/react-query-devtools": "^5.62.11",
     "@tanstack/react-table": "^8.20.5",

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -8,7 +8,7 @@ const config = {
   content: [
     "./app/**/*.{ts,tsx}",
     "./index.html",
-    "./node_modules/@seliseblocks/blocks-kit/dist/**/*.{js,jsx,ts,tsx}",
+    "./node_modules/@seliseblocks/genesis-os/dist/**/*.{js,jsx,ts,tsx}",
   ],
   prefix: "",
   theme: {


### PR DESCRIPTION
The shared app-shell package was renamed and rebaselined at 4.0.0. The exported API is unchanged, so this is a specifier rewrite across 288 source files plus three config files.

Two changes sed could not reach from app/:

- package.json: genesis-os starts at 4.0.0, so carrying the old 0.0.71 pin across the rename would have been unresolvable.
- tailwind.config.ts: the content glob still scanned the old dist path. This one fails silently — the build succeeds and Tailwind simply stops generating the package's utility classes. It cost 27 kB of CSS (146.66 kB to 119.60 kB) before being caught; the bundle is back to 146.9 kB now.

Verified with type-check and a production build.