### PR TITLE
fix(identifier): send repo domain update to Logic absolute URL

### DIFF
--- a/client/app/cross-modules/identifier/services/project.service.ts
+++ b/client/app/cross-modules/identifier/services/project.service.ts
@@ -86,7 +86,9 @@ export class ProjectService {
     errors: unknown | null;
     isSuccess: boolean;
   }> {
-    return http.post(CLOUD_BUILD_ENDPOINTS.REPO_UPDATE, payload);
+    return http.post(CLOUD_BUILD_ENDPOINTS.REPO_UPDATE, payload, undefined, {
+      absoluteUrl: true,
+    });
   }
 
   // Resolves the project from the caller's auth context — there is no


### PR DESCRIPTION
Without absoluteUrl, HttpClient prepends BLOCKS_OS_BASE_URL to the already-absolute Logic endpoint and produces a malformed double host.