### PR TITLE
feat(ci): add LMT Managed Service Worker support in CI/CD workflows and Dockerfile

### DIFF
--- a/.github/variables/vars.env
+++ b/.github/variables/vars.env
@@ -9,4 +9,5 @@ SCA_PROJECT_CLIENT=blocks-os-client
 SERVICE_NAME=blocks-os
 DOCKERFILE_CLIENT=Dockerfile
 DOCKERFILE_WORKER=Dockerfile.worker
+DOCKERFILE_LMT_WORKER=Dockerfile.Lmt.worker
 DOTNET_VERSION=10.0.x

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -67,6 +67,7 @@ jobs:
       version: ${{ steps.config.outputs.version }} # Version suffix based on environment
       client_dockerfile_path: ${{ steps.config.outputs.client_dockerfile_path }} # Path to Dockerfile
       worker_dockerfile_path: ${{ steps.config.outputs.worker_dockerfile_path }} # Path to Window/Console service Dockerfile
+      lmt_worker_dockerfile_path: ${{ steps.config.outputs.lmt_worker_dockerfile_path }} # Path to LMT Managed Service Worker Dockerfile
       dependency_track_host: ${{ steps.config.outputs.dependency_track_host }} # e.g., api-dt.seliseblocks.com
       dependency_track_frontend_url: ${{ steps.config.outputs.dependency_track_frontend_url }} # e.g., sca.seliseblocks.com
       dotnet_version: ${{ steps.config.outputs.dotnet_version }}
@@ -96,6 +97,7 @@ jobs:
           # From vars.env (if loaded) or fallback to defaults
           echo "client_dockerfile_path=${DOCKERFILE_CLIENT:-./Dockerfile}" >> $GITHUB_OUTPUT
           echo "worker_dockerfile_path=${DOCKERFILE_WORKER:-./Dockerfile.worker}" >> $GITHUB_OUTPUT
+          echo "lmt_worker_dockerfile_path=${DOCKERFILE_LMT_WORKER:-./Dockerfile.Lmt.worker}" >> $GITHUB_OUTPUT
 
           # From vars.env (if loaded) or fallback to defaults
           echo "service_name=${SERVICE_NAME:-github.event.repository.name}" >> $GITHUB_OUTPUT
@@ -370,6 +372,55 @@ jobs:
       COMMIT_TAG: ${{ needs.build-worker.outputs.commit_tag }}
       SEMANTIC_TAG: ${{ needs.build-worker.outputs.semantic_tag }}
       TAG_STRATEGY: ${{ needs.initialization.outputs.tag_strategy }} # Options: "commit" (default), "semantic", or "primary"
+      CLUSTER_NAME: ${{ needs.initialization.outputs.cluster_name }}
+      # GITOPS_BRANCH: "main"
+    secrets:
+      SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}
+      AZURE_CONTAINER_REGISTRY: ${{ secrets.AZURE_BLOCKS_CONTAINER_REGISTRY }}
+
+  # Build and push image
+  build-lmt-worker:
+    needs: [initialization, sonarqube_server, sonarqube_client]
+    if: |
+      github.event_name == 'push' &&
+      always() &&
+      needs.initialization.result == 'success' &&
+      (needs.sonarqube_server.result == 'success' || needs.sonarqube_server.result == 'skipped') &&
+      (needs.sonarqube_client.result == 'success' || needs.sonarqube_client.result == 'skipped')
+    uses: SELISEdigitalplatforms/blocks-inventory/.github/workflows/build-push.yml@main
+    with:
+      SERVICE_NAME: ${{ needs.initialization.outputs.service_name }}
+      SERVICE_TYPE: "lmt-worker"
+      ENVIRONMENT: ${{ needs.initialization.outputs.environment }}
+      TAG_STRATEGY: ${{ needs.initialization.outputs.tag_strategy }}
+      DOCKERFILE_PATH: ${{ needs.initialization.outputs.lmt_worker_dockerfile_path }}
+      # VERSION: ${{ needs.initialization.outputs.version }}
+      BUILD_ARGS: |
+        BUILD_VERSION=${{ github.sha }}
+    secrets:
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_AKS_BLOCKS_CREDENTIALS }}
+      AZURE_CONTAINER_REGISTRY: ${{ secrets.AZURE_BLOCKS_CONTAINER_REGISTRY }}
+      ACR_RESOURCE_GROUP: ${{ secrets.ClUSTER_AKS_BLOCKS_RESOURCE_GROUP }}
+      SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}
+
+  # Update GitOps repository
+  update-gitops-lmt-worker:
+    needs: [initialization, build-lmt-worker]
+    if: |
+      github.event_name == 'push' &&
+      always() &&
+      needs.initialization.result == 'success' &&
+      needs.build-lmt-worker.result == 'success'
+    uses: SELISEdigitalplatforms/blocks-inventory/.github/workflows/update-gitops-central.yml@main
+    with:
+      SERVICE_NAME: ${{ needs.initialization.outputs.service_name }}
+      SERVICE_TYPE: "lmt-worker"
+      ENVIRONMENT: ${{ needs.initialization.outputs.environment }}
+      # VERSION: ${{ needs.initialization.outputs.version }}
+      IMAGE_TAG: ${{ needs.build-lmt-worker.outputs.image_tag }}
+      COMMIT_TAG: ${{ needs.build-lmt-worker.outputs.commit_tag }}
+      SEMANTIC_TAG: ${{ needs.build-lmt-worker.outputs.semantic_tag }}
+      TAG_STRATEGY: ${{ needs.initialization.outputs.tag_strategy }}
       CLUSTER_NAME: ${{ needs.initialization.outputs.cluster_name }}
       # GITOPS_BRANCH: "main"
     secrets:

--- a/.github/workflows/ci-stg.yml
+++ b/.github/workflows/ci-stg.yml
@@ -67,6 +67,7 @@ jobs:
       version: ${{ steps.config.outputs.version }} # Version suffix based on environment
       client_dockerfile_path: ${{ steps.config.outputs.client_dockerfile_path }} # Path to Dockerfile
       worker_dockerfile_path: ${{ steps.config.outputs.worker_dockerfile_path }} # Path to Window/Console service Dockerfile
+      lmt_worker_dockerfile_path: ${{ steps.config.outputs.lmt_worker_dockerfile_path }} # Path to LMT Managed Service Worker Dockerfile
       dependency_track_host: ${{ steps.config.outputs.dependency_track_host }} # e.g., api-dt.seliseblocks.com
       dependency_track_frontend_url: ${{ steps.config.outputs.dependency_track_frontend_url }} # e.g., sca.seliseblocks.com
       dotnet_version: ${{ steps.config.outputs.dotnet_version }}
@@ -96,6 +97,7 @@ jobs:
           # From vars.env (if loaded) or fallback to defaults
           echo "client_dockerfile_path=${DOCKERFILE_CLIENT:-./Dockerfile}" >> $GITHUB_OUTPUT
           echo "worker_dockerfile_path=${DOCKERFILE_WORKER:-./Dockerfile.worker}" >> $GITHUB_OUTPUT
+          echo "lmt_worker_dockerfile_path=${DOCKERFILE_LMT_WORKER:-./Dockerfile.Lmt.worker}" >> $GITHUB_OUTPUT
 
           # From vars.env (if loaded) or fallback to defaults
           echo "service_name=${SERVICE_NAME:-github.event.repository.name}" >> $GITHUB_OUTPUT
@@ -363,6 +365,55 @@ jobs:
       IMAGE_TAG: ${{ needs.build-worker.outputs.image_tag }}
       COMMIT_TAG: ${{ needs.build-worker.outputs.commit_tag }}
       SEMANTIC_TAG: ${{ needs.build-worker.outputs.semantic_tag }}
+      TAG_STRATEGY: ${{ needs.initialization.outputs.tag_strategy }}
+      CLUSTER_NAME: ${{ needs.initialization.outputs.cluster_name }}
+      # GITOPS_BRANCH: "main"
+    secrets:
+      SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}
+      AZURE_CONTAINER_REGISTRY: ${{ secrets.AZURE_BLOCKS_CONTAINER_REGISTRY }}
+
+  # Build and push image
+  build-lmt-worker:
+    needs: [initialization, sonarqube_server, sonarqube_client]
+    if: |
+      github.event_name == 'push' &&
+      always() &&
+      needs.initialization.result == 'success' &&
+      (needs.sonarqube_server.result == 'success' || needs.sonarqube_server.result == 'skipped') &&
+      (needs.sonarqube_client.result == 'success' || needs.sonarqube_client.result == 'skipped')
+    uses: SELISEdigitalplatforms/blocks-inventory/.github/workflows/build-push.yml@main
+    with:
+      SERVICE_NAME: ${{ needs.initialization.outputs.service_name }}
+      SERVICE_TYPE: "lmt-worker"
+      ENVIRONMENT: ${{ needs.initialization.outputs.environment }}
+      TAG_STRATEGY: ${{ needs.initialization.outputs.tag_strategy }}
+      DOCKERFILE_PATH: ${{ needs.initialization.outputs.lmt_worker_dockerfile_path }}
+      # VERSION: ${{ needs.initialization.outputs.version }}
+      BUILD_ARGS: |
+        BUILD_VERSION=${{ github.sha }}
+    secrets:
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_AKS_BLOCKS_CREDENTIALS }}
+      AZURE_CONTAINER_REGISTRY: ${{ secrets.AZURE_BLOCKS_CONTAINER_REGISTRY }}
+      ACR_RESOURCE_GROUP: ${{ secrets.ClUSTER_AKS_BLOCKS_RESOURCE_GROUP }}
+      SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}
+
+  # Update GitOps repository
+  update-gitops-lmt-worker:
+    needs: [initialization, build-lmt-worker]
+    if: |
+      github.event_name == 'push' &&
+      always() &&
+      needs.initialization.result == 'success' &&
+      needs.build-lmt-worker.result == 'success'
+    uses: SELISEdigitalplatforms/blocks-inventory/.github/workflows/update-gitops-central.yml@main
+    with:
+      SERVICE_NAME: ${{ needs.initialization.outputs.service_name }}
+      SERVICE_TYPE: "lmt-worker"
+      ENVIRONMENT: ${{ needs.initialization.outputs.environment }}
+      # VERSION: ${{ needs.initialization.outputs.version }}
+      IMAGE_TAG: ${{ needs.build-lmt-worker.outputs.image_tag }}
+      COMMIT_TAG: ${{ needs.build-lmt-worker.outputs.commit_tag }}
+      SEMANTIC_TAG: ${{ needs.build-lmt-worker.outputs.semantic_tag }}
       TAG_STRATEGY: ${{ needs.initialization.outputs.tag_strategy }}
       CLUSTER_NAME: ${{ needs.initialization.outputs.cluster_name }}
       # GITOPS_BRANCH: "main"

--- a/.github/workflows/ci_prod.yml
+++ b/.github/workflows/ci_prod.yml
@@ -67,6 +67,7 @@ jobs:
       version: ${{ steps.config.outputs.version }} # Version suffix based on environment
       client_dockerfile_path: ${{ steps.config.outputs.client_dockerfile_path }} # Path to Dockerfile
       worker_dockerfile_path: ${{ steps.config.outputs.worker_dockerfile_path }} # Path to Window/Console service Dockerfile
+      lmt_worker_dockerfile_path: ${{ steps.config.outputs.lmt_worker_dockerfile_path }} # Path to LMT Managed Service Worker Dockerfile
       dependency_track_host: ${{ steps.config.outputs.dependency_track_host }} # e.g., api-dt.seliseblocks.com
       dependency_track_frontend_url: ${{ steps.config.outputs.dependency_track_frontend_url }} # e.g., sca.seliseblocks.com
       dotnet_version: ${{ steps.config.outputs.dotnet_version }}
@@ -96,6 +97,7 @@ jobs:
           # From vars.env (if loaded) or fallback to defaults
           echo "client_dockerfile_path=${DOCKERFILE_CLIENT:-./Dockerfile}" >> $GITHUB_OUTPUT
           echo "worker_dockerfile_path=${DOCKERFILE_WORKER:-./Dockerfile.worker}" >> $GITHUB_OUTPUT
+          echo "lmt_worker_dockerfile_path=${DOCKERFILE_LMT_WORKER:-./Dockerfile.Lmt.worker}" >> $GITHUB_OUTPUT
 
           # From vars.env (if loaded) or fallback to defaults
           echo "service_name=${SERVICE_NAME:-github.event.repository.name}" >> $GITHUB_OUTPUT
@@ -363,6 +365,55 @@ jobs:
       IMAGE_TAG: ${{ needs.build-worker.outputs.image_tag }}
       COMMIT_TAG: ${{ needs.build-worker.outputs.commit_tag }}
       SEMANTIC_TAG: ${{ needs.build-worker.outputs.semantic_tag }}
+      TAG_STRATEGY: ${{ needs.initialization.outputs.tag_strategy }}
+      CLUSTER_NAME: ${{ needs.initialization.outputs.cluster_name }}
+      # GITOPS_BRANCH: "main"
+    secrets:
+      SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}
+      DOCKERHUB_ORG: ${{ secrets.DOCKERHUB_ORG }}
+
+  # Build and push image
+  build-lmt-worker:
+    needs: [initialization, sonarqube_server, sonarqube_client]
+    if: |
+      github.event_name == 'push' &&
+      always() &&
+      needs.initialization.result == 'success' &&
+      (needs.sonarqube_server.result == 'success' || needs.sonarqube_server.result == 'skipped') &&
+      (needs.sonarqube_client.result == 'success' || needs.sonarqube_client.result == 'skipped')
+    uses: SELISEdigitalplatforms/blocks-inventory/.github/workflows/build-push.yml@main
+    with:
+      SERVICE_NAME: ${{ needs.initialization.outputs.service_name }}
+      SERVICE_TYPE: "lmt-worker"
+      ENVIRONMENT: ${{ needs.initialization.outputs.environment }}
+      TAG_STRATEGY: ${{ needs.initialization.outputs.tag_strategy }}
+      DOCKERFILE_PATH: ${{ needs.initialization.outputs.lmt_worker_dockerfile_path }}
+      # VERSION: ${{ needs.initialization.outputs.version }}
+      BUILD_ARGS: |
+        BUILD_VERSION=${{ github.sha }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_ORG: ${{ secrets.DOCKERHUB_ORG }}
+      SELISE_GITHUB_PAT: ${{ secrets.SELISE_GITHUB_PAT }}
+
+  # Update GitOps repository
+  update-gitops-lmt-worker:
+    needs: [initialization, build-lmt-worker]
+    if: |
+      github.event_name == 'push' &&
+      always() &&
+      needs.initialization.result == 'success' &&
+      needs.build-lmt-worker.result == 'success'
+    uses: SELISEdigitalplatforms/blocks-inventory/.github/workflows/update-gitops-central.yml@main
+    with:
+      SERVICE_NAME: ${{ needs.initialization.outputs.service_name }}
+      SERVICE_TYPE: "lmt-worker"
+      ENVIRONMENT: ${{ needs.initialization.outputs.environment }}
+      # VERSION: ${{ needs.initialization.outputs.version }}
+      IMAGE_TAG: ${{ needs.build-lmt-worker.outputs.image_tag }}
+      COMMIT_TAG: ${{ needs.build-lmt-worker.outputs.commit_tag }}
+      SEMANTIC_TAG: ${{ needs.build-lmt-worker.outputs.semantic_tag }}
       TAG_STRATEGY: ${{ needs.initialization.outputs.tag_strategy }}
       CLUSTER_NAME: ${{ needs.initialization.outputs.cluster_name }}
       # GITOPS_BRANCH: "main"

--- a/Dockerfile.Lmt.worker
+++ b/Dockerfile.Lmt.worker
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# Blocks OS LMT Managed Service Worker: background workers / consumers only (no HTTP host)
+# Build: docker build -f Dockerfile.Lmt.worker -t blocks-os-lmt-worker .
+# =============================================================================
+
+ARG DOTNET_PUBLISH_PLATFORM=linux/amd64
+
+# -----------------------------------------------------------------------------
+# Stage: publish: .NET SDK (glibc). Default platform linux/amd64 avoids Grpc.Tools
+# protoc crashes on some arm64 build hosts; override if your CI publishes safely
+# on arm64: docker build --build-arg DOTNET_PUBLISH_PLATFORM=linux/arm64 .
+# -----------------------------------------------------------------------------
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish
+WORKDIR /src
+
+COPY server ./server
+
+RUN dotnet publish server/LmtManagedServiceWorker/LmtManagedServiceWorker.csproj \
+    -c Release \
+    -o /app/publish \
+    --no-self-contained \
+    -p:DebugType=None
+
+# -----------------------------------------------------------------------------
+# Stage: runtime: ASP.NET Core runtime on Alpine (Worker targets shared
+# Microsoft.AspNetCore.App via the Worker SDK / dependencies.)
+# -----------------------------------------------------------------------------
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
+
+ARG BUILD_VERSION=0.0.0
+LABEL org.opencontainers.image.title="blocks-os-lmt-worker" \
+    org.opencontainers.image.description="Blocks OS LMT managed service worker (Generic Host, message consumers)." \
+    org.opencontainers.image.version="${BUILD_VERSION}"
+
+WORKDIR /app
+
+ENV DOTNET_ENVIRONMENT=Production \
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
+RUN apk add --no-cache icu-libs
+
+COPY --from=publish /app/publish .
+RUN chown -R app:app /app
+
+USER app
+
+ENTRYPOINT ["dotnet", "LmtManagedServiceWorker.dll"]


### PR DESCRIPTION
## Summary
- Fix `Dockerfile.Lmt.worker` (copy-paste from `Dockerfile.worker`) to publish `server/LmtManagedServiceWorker/LmtManagedServiceWorker.csproj` and run `LmtManagedServiceWorker.dll`.
- Add `build-lmt-worker` + `update-gitops-lmt-worker` jobs (SERVICE_TYPE `lmt-worker`) to `ci-dev.yml`, `ci-stg.yml`, `ci_prod.yml`, parallel to the existing `worker` jobs.
- Add `DOCKERFILE_LMT_WORKER` to `.github/variables/vars.env`.

## Blocker before merge/deploy
`update-gitops-lmt-worker` requires `blocks-os-lmt-worker.values.yaml` per cluster (dev/stg/prod) in `l0-yml-argo-helm`. Not created yet — add it there first or that job will fail with "Values file not found".

## Test plan
- [x] `docker build -f Dockerfile.Lmt.worker -t blocks-os-lmt-worker .` succeeds locally, publishes `LmtManagedServiceWorker.dll`.
- [ ] Create `blocks-os-lmt-worker.values.yaml` in `l0-yml-argo-helm` for dev/stg/prod.
- [ ] Merge, confirm `ci-dev.yml` build-lmt-worker + update-gitops-lmt-worker succeed.