### PR TITLE
fix(identifier): use absolute URL for verifyMigration endpoint

### DIFF
--- a/client/app/cross-modules/identifier/services/project.service.ts
+++ b/client/app/cross-modules/identifier/services/project.service.ts
@@ -128,7 +128,7 @@ export class ProjectService {
   verifyMigration(
     payload: IVerifyMigrationRequest,
   ): Promise<IMigrationVerificationResponse> {
-    return http.post(MIGRATION_ENDPOINTS.VERIFY, payload);
+    return http.post(MIGRATION_ENDPOINTS.VERIFY, payload, undefined, { absoluteUrl: true });
   }
 
   getMigrationStatus(tenantGroupId: string): Promise<IMigrationStatusResponse> {


### PR DESCRIPTION
Migration verify calls the logic API directly, matching initiateMigration and getMigrationStatus so the request hits the correct backend host.