### PR TITLE
Add open-source baseline files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,119 @@
+# Environment variables for this repository.
+# Copy to .env and fill in real values. Never commit .env.
+# Keys only: every value here is intentionally blank.
+
+# app environment (was /opt/blocks/secrets/.env)
+# Base credentials and ports. Single source of truth, interpolated into
+# Docker Compose containers and composed into BlocksSecret__* connection
+# strings by run.sh at launch.
+MONGO_USER=
+MONGO_PASS=
+MONGO_HOST_PORT=
+REDIS_HOST_PORT=
+RABBITMQ_USER=
+RABBITMQ_PASS=
+RABBITMQ_HOST_PORT=
+RABBITMQ_MGMT_PORT=
+
+# Application config consumed by .NET services.
+# Connection strings (Cache/Message/Lmt/Database/Log/Metric/Trace) are composed
+# from the variables above and exported by run.sh at launch, do not duplicate
+# them here.
+BlocksSecret__RootDatabaseName=
+BlocksSecret__LogDatabaseName=
+BlocksSecret__MetricDatabaseName=
+BlocksSecret__TraceDatabaseName=
+BlocksSecret__EnableHsts=
+BLOCKS_VAULT_TYPE=
+
+# Deployment (used by the `apps` and `edge` Compose profiles).
+# DOMAIN is the base domain; every web app gets <subdomain>.${DOMAIN}.
+# LETSENCRYPT_EMAIL is the contact for cert renewal notices.
+# BLOCKS_VERSION is the image tag pulled for every seliseblocks/* image.
+DOMAIN=
+LETSENCRYPT_EMAIL=
+BLOCKS_VERSION=
+OS_TAG=
+IAM_TAG=
+LOCALIZATION_TAG=
+OS_TAG_LAST=
+IAM_TAG_LAST=
+
+# Client Configuration, fill these in before running  bash run.sh
+
+# Root tenant ID. Do not change unless you know what you are doing.
+ROOT_TENANT_ID=
+
+# MongoDB connection string written into EVERY tenant's DbConnectionString.
+# Inside Docker Compose the hostname is "mongodb"; for an external cluster
+# replace with your actual connection string.
+TENANT_DB_CONNECTION_STRING=
+
+# --- Per-service URLs ---
+# Set the full URL for each service. If left blank, defaults to https://<svc>.DOMAIN
+OS_URL=
+IAM_URL=
+DATA_URL=
+LOGIC_URL=
+LOCALIZATION_URL=
+STUDIO_URL=
+RELEASE_URL=
+MONITOR_URL=
+AGENTS_URL=
+UTILITIES_URL=
+
+# --- Per-service OIDC credentials ---
+# Leave blank to keep the UUID from the DB dump template.
+OS_CLIENT_ID=
+OS_CLIENT_SECRET=
+
+IAM_CLIENT_ID=
+IAM_CLIENT_SECRET=
+
+DATA_CLIENT_ID=
+DATA_CLIENT_SECRET=
+
+LOGIC_CLIENT_ID=
+LOGIC_CLIENT_SECRET=
+
+LOCALIZATION_CLIENT_ID=
+LOCALIZATION_CLIENT_SECRET=
+
+STUDIO_CLIENT_ID=
+STUDIO_CLIENT_SECRET=
+
+RELEASE_CLIENT_ID=
+RELEASE_CLIENT_SECRET=
+
+MONITOR_CLIENT_ID=
+MONITOR_CLIENT_SECRET=
+
+AGENTS_CLIENT_ID=
+AGENTS_CLIENT_SECRET=
+
+UTILITIES_CLIENT_ID=
+UTILITIES_CLIENT_SECRET=
+BlocksSecret__DatabaseConnectionString=
+BlocksSecret__CacheConnectionString=
+BlocksSecret__MessageConnectionString=
+BlocksSecret__LmtMessageConnectionString=
+BlocksSecret__LogConnectionString=
+BlocksSecret__MetricConnectionString=
+BlocksSecret__TraceConnectionString=
+BLOCKS_AI_PERPLEXICA_HOST=
+BLOCKS_AI_DEFAULT_ORG_ID=
+BLOCKS_AI_ENCRYPTION_KEY=
+KEYVAULT__KEYVAULTURL=
+
+# scan tokens (was /opt/blocks/secrets/scan.env)
+SONAR_TOKEN=
+DT_API_KEY=
+SHIELD_USER=
+SHIELD_PASS=
+DD_TOKEN=
+SHIELD_VIEW_USER=
+SHIELD_VIEW_PASS=
+GH_PROJECT_TOKEN=
+
+# was /opt/blocks/secrets/.shield_ci_pass
+SHIELD_CI_PASS=

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+/.gitignore         @rezwanx
+**/.gitignore       @rezwanx
+/.gitattributes     @rezwanx
+/.github/workflows/ @rezwanx

--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,10 @@ copilot-instructions.md
 !SECURITY.md
 !CODE_OF_CONDUCT.md
 scripts/scan.sh
+
+# --- open-source baseline: secrets, build output, local agent files ---
+build/
+QWEN.md
+.clinerules
+.windsurfrules
+results/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,49 @@
+# gitleaks configuration for this repository.
+#
+# Starts from the upstream default rule set and adds a narrow allowlist for the
+# categories that are documentation, test fixtures, or generated manifests. The
+# allowlist is deliberately specific: it matches placeholder shapes and known
+# non-secret file layouts, not whole directories of real code.
+#
+# Run locally with: gitleaks dir . --config .gitleaks.toml
+#                   gitleaks git . --config .gitleaks.toml
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Documentation placeholders, test fixtures, and generated manifests"
+
+paths = [
+  # Release manifests: one container image tag per line. The tag suffix is a build
+  # hash, which trips the generic high-entropy rules.
+  '''(^|/)blocks-[a-z0-9-]+/(api|worker)/(prod|stg|enterprise)\.txt$''',
+
+  # Secret-detection source: this file contains the regexes used to find private
+  # keys, so it necessarily looks like it contains one.
+  '''(^|/)guardrail_validator\.py$''',
+
+  # Frontend and backend unit tests use fabricated credentials as fixtures.
+  '''\.test\.(ts|tsx|js|jsx)$''',
+  '''(^|/)XUnitTest/.*Tests\.cs$''',
+]
+
+regexes = [
+  # Environment variable references, not values: $TOKEN, ${SONAR_GET}, $API_BASE_URL.
+  # A real credential never contains "${...}", so treat any such capture as a reference.
+  '''^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$''',
+  '''\$\{[A-Za-z_][A-Za-z0-9_]*\}''',
+
+  # Documentation placeholders.
+  # A value containing an ellipsis is an elided example (for example "eyJhbGci..."),
+  # not a usable credential.
+  '''\.\.\.''',
+  '''YOUR_[A-Z_]+''',
+  '''<your-[a-z-]+>''',
+  '''TEST_KEY_[0-9]+''',
+  '''^(test|fake|dummy|sample|example|placeholder|changeme|redacted)[-_A-Za-z0-9]*$''',
+  '''^sk-(test|fake|dummy)''',
+
+  # Container image tag suffix: <short-sha>-<build>-<calver>.
+  '''^[0-9a-f]{7,}-[0-9]+-[0-9]+\.[0-9]+\.?[0-9]*$''',
+]


### PR DESCRIPTION
Adds the governance, tooling and hygiene files these repositories need before going public.

Per repo, only what was missing:

- `LICENSE` (MIT), `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
- `.editorconfig`, `.github/CODEOWNERS`, `.dockerignore` where a container is built
- `.gitleaks.toml`: upstream default rules, no allowlisting of real findings
- `.env.example`: key names only, every value blank
- `.gitignore`: extended to cover `.env*`, build output, and local agent instruction files
- `README.md`: standard "Contributing and security" and "License" sections

No functional code changes. Conventions follow blocks-iam and blocks-os.