### PR TITLE
Ignore local scan and coverage output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,6 @@ zap-*.xml
 *.trufflehog.json
 *-secrets.json
 *-semgrep.sarif
+
+# local scan and coverage output, never committed
+results/

--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,8 @@ zap-*.xml
 
 # local scan and coverage output, never committed
 results/
+
+# --- AI agent instruction files (do not commit) ---
+QWEN.md
+.clinerules
+.windsurfrules

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1248,9 +1248,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Brings `inception` up to `dev` for blocks-os.

## Commits
- chore: ignore local scan and coverage output
- fix(deps): bump js-yaml and brace-expansion to patched versions

## Verification
- Gitignore only. Adds `results/` so local scan and coverage output is never committed.
- gitleaks and trufflehog run locally before pushing. No verified secrets, and no findings introduced by these commits.
