### PR TITLE
[#472] IAM: Archive actions for Roles and Permissions (Blocks OS UI)

### DIFF
--- a/client/app/cross-modules/idp/iam/components/archive-action.tsx
+++ b/client/app/cross-modules/idp/iam/components/archive-action.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
+import { isErrorWithErrors } from "@/lib/error";
+import { ARCHIVE_ERROR_MESSAGES, normalizeArchiveErrors } from "../constants/archive-error-messages";
+
+type ArchiveActionProps = {
+  /** What is being archived, for the dialog copy and the button's accessible name. */
+  entity: "role" | "permission";
+  name: string;
+  /** The per-row mutation. Instantiated by the caller *inside* the row, never hoisted. */
+  archive: (id: string) => Promise<unknown>;
+  isPending: boolean;
+  itemId: string;
+};
+
+/**
+ * Trash button plus its confirm dialog, for one row.
+ *
+ * Both lists render this per row so that `isPending` is scoped to the row being archived. The
+ * obvious model to copy — `SignOutButton` in session-list-card — takes `mutateAsync` and
+ * `isPending` as props from a single parent hook, which would make one row's archive disable every
+ * other row's confirm button.
+ */
+export const ArchiveAction = ({
+  entity,
+  name,
+  archive,
+  isPending,
+  itemId,
+}: ArchiveActionProps) => {
+  const [open, setOpen] = useState(false);
+
+  const handleConfirm = async () => {
+    try {
+      await archive(itemId);
+      showSuccessToast({
+        description: `${entity === "role" ? "Role" : "Permission"} archived successfully`,
+      });
+      setOpen(false);
+    } catch (error) {
+      // Rejections arrive thrown, never as a resolved failure, so there is no `isSuccess` branch
+      // here. The dialog deliberately stays open so the reason is read next to the action.
+      const dictionary =
+        normalizeArchiveErrors(error) ?? (isErrorWithErrors(error) ? error.errors : undefined);
+
+      // An empty dictionary counts as absent. The HTTP client attaches `errors: {}` to a transport
+      // failure, and a plain `??` would keep it, leaving getErrorMessage to answer with its generic
+      // "Something went wrong." instead of the archive-specific copy.
+      const errors =
+        dictionary && Object.keys(dictionary).length > 0
+          ? dictionary
+          : "Something went wrong while archiving.";
+
+      // The dictionary and the map go in raw; showErrorToast runs the lookup itself. Mapping here
+      // first yielded a string[], and handleErrorMessages collapses any array to "An unexpected
+      // error occurred." -- so the mapped copy was computed and then discarded.
+      showErrorToast({ errors, customMessages: ARCHIVE_ERROR_MESSAGES });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      {/* DialogTrigger rather than a manual setOpen: Radix needs the trigger reference to
+          return focus to this button after Cancel, Escape or a successful archive. */}
+      <DialogTrigger asChild>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="rounded-full"
+          aria-label={`Archive ${entity} ${name}`}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>Archive this {entity}?</DialogTitle>
+          <DialogDescription>
+            {name} will be archived and hidden from this list. Existing records are kept, so nothing
+            is permanently deleted.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleConfirm} disabled={isPending}>
+            {isPending ? "Archiving..." : "Archive"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/idp/iam/constants/archive-error-messages.test.ts
+++ b/client/app/cross-modules/idp/iam/constants/archive-error-messages.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { getErrorMessage } from "@/lib/error";
+import { ARCHIVE_ERROR_MESSAGES, normalizeArchiveErrors } from "./archive-error-messages";
+
+/**
+ * The exact set of reason codes the two archive endpoints can return, taken from the blocks-iam
+ * source rather than from prose: five from ArchivePermissionAsync and six from ArchiveRoleAsync.
+ * Each is pinned by an XUnit assertion there, so this list drifting means the backend changed.
+ */
+const BACKEND_CODES = [
+  "Not_Allowed_To_Archive_Permission_Outside_Default_Organization",
+  "Permission_Not_Found",
+  "Permission_Not_A_Default_Organization_Record",
+  "Permission_Already_Archived",
+  "Only_Root_Tenant_Can_Archive_Built_In_Permission",
+  "Role_Not_Found",
+  "Can_Not_Archive_Default_Copied_Role",
+  "Not_Allowed_To_Archive_Role_From_Another_Organization",
+  "Role_Already_Archived",
+  "Role_Has_Child_Roles",
+  "Role_Has_Active_User_Assignments",
+];
+
+describe("ARCHIVE_ERROR_MESSAGES", () => {
+  it("covers exactly the codes the backend emits, no more and no fewer", () => {
+    // Equality, not containment: a missing code means a blank-looking toast, and an extra one
+    // means dead copy that will quietly rot.
+    expect(Object.keys(ARCHIVE_ERROR_MESSAGES).sort()).toEqual([...BACKEND_CODES].sort());
+  });
+
+  it.each(BACKEND_CODES)("maps %s to non-empty copy", (code) => {
+    expect(ARCHIVE_ERROR_MESSAGES[code]?.trim().length).toBeGreaterThan(0);
+  });
+
+  it("resolves a real backend payload to its specific message", () => {
+    // The category key is ambiguous -- "forbidden" alone covers five reasons -- so this is the
+    // end-to-end check that the value is what gets looked up.
+    expect(
+      getErrorMessage({ dependency: "Role_Has_Child_Roles" }, ARCHIVE_ERROR_MESSAGES),
+    ).toEqual([ARCHIVE_ERROR_MESSAGES.Role_Has_Child_Roles]);
+  });
+
+  it("falls back to the raw code if the backend adds a reason", () => {
+    // C7: drift degrades to today's behaviour rather than producing a blank toast.
+    expect(getErrorMessage({ forbidden: "Some_Future_Code" }, ARCHIVE_ERROR_MESSAGES)).toEqual([
+      "Some_Future_Code",
+    ]);
+  });
+});
+
+describe("normalizeArchiveErrors", () => {
+  it("reads a lowercase errors dictionary", () => {
+    expect(normalizeArchiveErrors({ errors: { archived: "Role_Already_Archived" } })).toEqual({
+      archived: "Role_Already_Archived",
+    });
+  });
+
+  it("reads a PascalCase Errors dictionary", () => {
+    // throwIfNotOk only looks for lowercase `errors`, so a PascalCase wire body would arrive with
+    // the whole response object on HttpError.errors and nothing would ever match.
+    expect(normalizeArchiveErrors({ Errors: { archived: "Role_Already_Archived" } })).toEqual({
+      archived: "Role_Already_Archived",
+    });
+  });
+
+  it("unwraps the nested shape the client produces for a PascalCase body", () => {
+    // What HttpError.errors actually holds when the body was { isSuccess, Errors }.
+    expect(
+      normalizeArchiveErrors({
+        errors: { isSuccess: false, Errors: { dependency: "Role_Has_Child_Roles" } },
+      }),
+    ).toEqual({ dependency: "Role_Has_Child_Roles" });
+  });
+
+  it("returns undefined for anything else", () => {
+    expect(normalizeArchiveErrors(new Error("boom"))).toBeUndefined();
+    expect(normalizeArchiveErrors(null)).toBeUndefined();
+    expect(normalizeArchiveErrors("nope")).toBeUndefined();
+  });
+});

--- a/client/app/cross-modules/idp/iam/constants/archive-error-messages.ts
+++ b/client/app/cross-modules/idp/iam/constants/archive-error-messages.ts
@@ -1,0 +1,71 @@
+/**
+ * Human-readable copy for every rejection the two IAM archive endpoints can return.
+ *
+ * The backend keys its error dictionary by *category* (`forbidden`, `ItemId`, `archived`,
+ * `dependency`) and puts the specific reason in the *value*, so this map is keyed on the value:
+ * `forbidden` alone covers five distinct reasons across the two endpoints, and the other three
+ * categories cover two each. Mapping by key could not tell them apart.
+ *
+ * Deliberately feature-local rather than a global registry — see the ticket's out-of-scope list.
+ * An unmapped code falls through to the raw value in `getErrorMessage`, so if the backend ever
+ * adds a reason the toast degrades to today's behaviour instead of going blank.
+ */
+export const ARCHIVE_ERROR_MESSAGES: Record<string, string> = {
+  // DELETE /iam/permissions/{id}
+  Not_Allowed_To_Archive_Permission_Outside_Default_Organization:
+    "Permissions can only be archived from the default organization.",
+  Permission_Not_Found: "This permission no longer exists. Refresh the list and try again.",
+  Permission_Not_A_Default_Organization_Record:
+    "This is another organization's copy of the permission. Archive the default-organization record instead.",
+  Permission_Already_Archived: "This permission is already archived.",
+  Only_Root_Tenant_Can_Archive_Built_In_Permission:
+    "Built-in permissions can only be archived by a root-tenant administrator.",
+
+  // DELETE /iam/roles/{id}
+  Role_Not_Found: "This role no longer exists. Refresh the list and try again.",
+  Can_Not_Archive_Default_Copied_Role:
+    "This role was copied from the default organization and cannot be archived here.",
+  Not_Allowed_To_Archive_Role_From_Another_Organization:
+    "This role belongs to another organization.",
+  Role_Already_Archived: "This role is already archived.",
+  Role_Has_Child_Roles: "Archive or reassign this role's child roles first.",
+  Role_Has_Active_User_Assignments:
+    "This role is still assigned to active users. Remove those assignments first.",
+};
+
+/**
+ * What the archive endpoints resolve with on success. Failures do not arrive this way — they are
+ * thrown — but the shape is declared so the hooks can defend against a 200 that carries
+ * `isSuccess: false`, which the HTTP client would otherwise pass through as a success.
+ */
+export type ArchiveResponse = {
+  isSuccess?: boolean;
+  itemId?: string;
+  errors?: Record<string, string | string[]>;
+  Errors?: Record<string, string | string[]>;
+};
+
+/**
+ * Pulls the error dictionary off whatever the failure turned out to be.
+ *
+ * `throwIfNotOk` reads a lowercase `errors` off the response body; if the wire format were ever
+ * PascalCase the whole body would land on `HttpError.errors` instead, and no code would match.
+ * ASP.NET Core's defaults produce lowercase and blocks-iam sets no naming policy, but that is a
+ * different repo on a different deploy cadence, so both spellings are accepted here rather than
+ * betting on it.
+ */
+export const normalizeArchiveErrors = (
+  source: unknown,
+): Record<string, string | string[]> | undefined => {
+  if (typeof source !== "object" || source === null) return undefined;
+
+  const candidate = source as { errors?: unknown; Errors?: unknown };
+  const errors = candidate.errors ?? candidate.Errors;
+  if (typeof errors !== "object" || errors === null) return undefined;
+
+  const nested = errors as { errors?: unknown; Errors?: unknown };
+  const unwrapped = nested.errors ?? nested.Errors;
+  const resolved = typeof unwrapped === "object" && unwrapped !== null ? unwrapped : errors;
+
+  return resolved as Record<string, string | string[]>;
+};

--- a/client/app/cross-modules/idp/iam/hooks/use-archive.test.tsx
+++ b/client/app/cross-modules/idp/iam/hooks/use-archive.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const h = vi.hoisted(() => ({
+  deleteRole: vi.fn(),
+  deletePermission: vi.fn(),
+}));
+
+vi.mock("@blocks-idp/iam/services/role.service", () => ({
+  roleService: { deleteRole: h.deleteRole },
+}));
+vi.mock("@blocks-idp/iam/services/iam.service", () => ({
+  iamService: { permission: { deletePermission: h.deletePermission } },
+}));
+
+import { useDeleteRole } from "./use-roles";
+import { useDeletePermission } from "./use-permission";
+
+describe("archive mutation hooks", () => {
+  let client: QueryClient;
+  let invalidate: ReturnType<typeof vi.spyOn>;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidate = vi.spyOn(client, "invalidateQueries").mockResolvedValue(undefined);
+  });
+
+  const cases = [
+    {
+      name: "role",
+      hook: useDeleteRole,
+      service: h.deleteRole,
+      key: "roles",
+      id: "role-1",
+    },
+    {
+      name: "permission",
+      hook: useDeletePermission,
+      service: h.deletePermission,
+      key: "permissions",
+      id: "perm-1",
+    },
+  ];
+
+  it.each(cases)("$name: invalidates the list after a successful archive", async (c) => {
+    c.service.mockResolvedValue({ isSuccess: true, itemId: c.id });
+    const { result } = renderHook(() => c.hook(), { wrapper });
+
+    await result.current.mutateAsync(c.id);
+
+    expect(c.service).toHaveBeenCalledWith(c.id);
+    await waitFor(() =>
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: [c.key] }),
+    );
+  });
+
+  it.each(cases)("$name: a thrown rejection does not invalidate", async (c) => {
+    c.service.mockRejectedValue(
+      Object.assign(new Error("bad request"), {
+        errors: { dependency: "Role_Has_Child_Roles" },
+      }),
+    );
+    const { result } = renderHook(() => c.hook(), { wrapper });
+
+    await expect(result.current.mutateAsync(c.id)).rejects.toBeDefined();
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)("$name: a resolved isSuccess:false rejects and does not invalidate", async (c) => {
+    // The guard lives in mutationFn, not in the component. `mutateAsync` only resolves after
+    // react-query has already classified the result and run onSuccess, so a component-level
+    // check would show the right toast while the list had already refetched. The
+    // no-invalidation half of this assertion is what fails if the guard moves.
+    c.service.mockResolvedValue({
+      isSuccess: false,
+      errors: { archived: "Role_Already_Archived" },
+    });
+    const { result } = renderHook(() => c.hook(), { wrapper });
+
+    const error = await result.current.mutateAsync(c.id).catch((e) => e);
+
+    expect((error as { errors: unknown }).errors).toEqual({
+      archived: "Role_Already_Archived",
+    });
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/client/app/cross-modules/idp/iam/hooks/use-permission.ts
+++ b/client/app/cross-modules/idp/iam/hooks/use-permission.ts
@@ -1,4 +1,5 @@
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { normalizeArchiveErrors } from "../constants/archive-error-messages";
 import { useMemo } from "react";
 import {
   IGetPermissionByIdPayload,
@@ -54,6 +55,29 @@ export const useAddPermission = () => {
   return useMutation({
     mutationKey: ["permission", "add"],
     mutationFn: iamService.permission.addPermission,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["permissions"] });
+    },
+  });
+};
+
+/**
+ * Archives a permission. Same reasoning as useDeleteRole for why the resolved-failure guard lives
+ * in mutationFn rather than in the component.
+ */
+export const useDeletePermission = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: ["permission", "delete"],
+    mutationFn: async (id: string) => {
+      const response = await iamService.permission.deletePermission(id);
+      if (response?.isSuccess === false) {
+        throw Object.assign(new Error("Archive failed"), {
+          errors: normalizeArchiveErrors(response) ?? { general: "Archive failed" },
+        });
+      }
+      return response;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["permissions"] });
     },

--- a/client/app/cross-modules/idp/iam/hooks/use-roles.ts
+++ b/client/app/cross-modules/idp/iam/hooks/use-roles.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { normalizeArchiveErrors } from "../constants/archive-error-messages";
 import { roleService } from "@blocks-idp/iam/services/role.service";
 import { GetRolesPayload } from "@blocks-idp/iam/models/role";
 
@@ -25,6 +26,36 @@ export const useAddRole = () => {
   return useMutation({
     mutationKey: ["role", "add"],
     mutationFn: roleService.addRole,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["roles"] });
+    },
+  });
+};
+
+/**
+ * Archives a role.
+ *
+ * The `isSuccess === false` check lives here rather than in the component on purpose: `mutateAsync`
+ * only resolves after react-query has already classified the result and run `onSuccess`, so a
+ * component-level guard would show the right error toast while the list had *already* refetched.
+ * Throwing inside `mutationFn` keeps `onSuccess` — and therefore invalidation — honest.
+ *
+ * These endpoints return 400 on failure, so this path should be unreachable; it costs nothing and
+ * the contract lives in another repo on another deploy cadence.
+ */
+export const useDeleteRole = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: ["role", "delete"],
+    mutationFn: async (id: string) => {
+      const response = await roleService.deleteRole(id);
+      if (response?.isSuccess === false) {
+        throw Object.assign(new Error("Archive failed"), {
+          errors: normalizeArchiveErrors(response) ?? { general: "Archive failed" },
+        });
+      }
+      return response;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["roles"] });
     },

--- a/client/app/cross-modules/idp/iam/models/role.ts
+++ b/client/app/cross-modules/idp/iam/models/role.ts
@@ -8,6 +8,12 @@ export interface IRole {
   canCreateOwn: boolean;
   count: number;
   createdFromDefault: boolean;
+  /**
+   * Soft-delete flag from the backend. Optional because the roles list endpoint already excludes
+   * archived roles, so the client never receives `true` today -- it documents the contract without
+   * forcing every fixture to carry a value that is always absent.
+   */
+  isArchived?: boolean;
   createdDate: string;
   lastUpdatedDate: string;
   createdBy: string;

--- a/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions-list.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions-list.test.tsx
@@ -38,6 +38,28 @@ vi.mock("@seliseblocks/genesis-os/hooks", () => ({
   useScopedPath: () => (path: string) => `/scoped/${path}`,
 }));
 
+const successToast = vi.fn();
+const errorToast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({
+  showSuccessToast: (...a: unknown[]) => successToast(...a),
+  showErrorToast: (...a: unknown[]) => errorToast(...a),
+}));
+
+const archivePermission = vi.fn();
+const archivePending = { value: false, perCall: [] as boolean[] };
+const useDeletePermissionSpy = vi.fn();
+vi.mock("@blocks-idp/iam/hooks/use-permission", () => ({
+  useDeletePermission: () => {
+    useDeletePermissionSpy();
+    // perCall gives each row its own pending value, which is the only way to tell a per-row hook
+    // from one shared flag.
+    const pending = archivePending.perCall.length
+      ? (archivePending.perCall.shift() ?? false)
+      : archivePending.value;
+    return { mutateAsync: archivePermission, isPending: pending };
+  },
+}));
+
 vi.mock("./permissions-filter-toolbar", () => ({
   usePermissionsSortQuaryParams: () => ({
     sortQueryParams: { property: "Name", isDescending: false },
@@ -88,13 +110,19 @@ describe("PermissionsList", () => {
   });
 
   it("renders loading skeletons and no table while loading", () => {
+    // C5. Asserting only "no table" would be satisfied by `return null`, so the skeleton itself and
+    // its row count are pinned.
     const { container } = render(<PermissionsList permissions={[]} isLoading />);
     expect(container.querySelector("table")).toBeNull();
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(5);
   });
 
   it("shows the empty-state message for no permissions", () => {
-    render(<PermissionsList permissions={[]} isLoading={false} />);
+    const { container } = render(<PermissionsList permissions={[]} isLoading={false} />);
     expect(screen.getByText("No permission found. Please create new permission.")).toBeTruthy();
+    // No skeleton and no per-row actions on the empty state.
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(0);
+    expect(screen.queryByRole("button", { name: /^Archive permission/ })).toBeNull();
   });
 
   it("renders permission rows with name, resource, source, severity and role count", () => {
@@ -120,7 +148,10 @@ describe("PermissionsList", () => {
     );
     const links = screen.getAllByTestId("edit-link");
     expect(links).toHaveLength(1);
-    expect(links[0].getAttribute("href")).toContain("perm-custom");
+    // Full equality, including the /scoped prefix. `toContain("perm-custom")` passed just as
+    // happily when the link was hard-coded to the unscoped /app/iam route -- and the row click
+    // that used to supply the scope no longer fires, because the actions cell stops propagation.
+    expect(links[0].getAttribute("href")).toBe("/scoped/iam/permission-detail/perm-custom");
   });
 
   it("navigates to the permission detail page when a row is clicked", async () => {
@@ -128,5 +159,141 @@ describe("PermissionsList", () => {
     render(<PermissionsList permissions={[customPermission]} isLoading={false} />);
     await user.click(screen.getByText("Manage Billing"));
     expect(navigate).toHaveBeenCalledWith("/scoped/iam/permission-detail/perm-custom");
+  });
+});
+
+describe("PermissionsList archive action", () => {
+  const renderList = (permissions: IPermission[]) =>
+    render(<PermissionsList permissions={permissions} isLoading={false} />);
+  const trash = (name = "Manage Billing") =>
+    screen.getByRole("button", { name: `Archive permission ${name}` });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    archivePending.value = false;
+    archivePermission.mockResolvedValue({ isSuccess: true });
+  });
+
+  it("renders an archive action for every permission, built-in included", () => {
+    // C8's unit-testable half. Archiving a permission requires the caller to be in the default
+    // organization, but no client-side signal for that exists, so the action cannot be hidden --
+    // the rejection is what informs the user. The org-dependent behaviour is e2e-only.
+    renderList([customPermission, builtInPermission]);
+    expect(trash()).toBeTruthy();
+    expect(trash("Read Users")).toBeTruthy();
+  });
+
+  it("opens a confirm dialog without sending a request", async () => {
+    // H4
+    const user = userEvent.setup();
+    renderList([customPermission]);
+    await user.click(trash());
+    expect(screen.getByText("Archive this permission?")).toBeTruthy();
+    expect(archivePermission).not.toHaveBeenCalled();
+  });
+
+  it("cancels without sending a request", async () => {
+    // H5
+    const user = userEvent.setup();
+    renderList([customPermission]);
+    await user.click(trash());
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(archivePermission).not.toHaveBeenCalled();
+  });
+
+  it("drops the open dialog rather than retargeting it when the list changes underneath", async () => {
+    // See the roles-list counterpart: the row remounts and the confirmation closes, so Confirm can
+    // never land on a permission the user did not choose.
+    const other: IPermission = { ...customPermission, itemId: "perm-other", name: "Manage Users" };
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <PermissionsList permissions={[other, customPermission]} isLoading={false} />,
+    );
+
+    await user.click(trash("Manage Billing"));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    rerender(<PermissionsList permissions={[customPermission]} isLoading={false} />);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(archivePermission).not.toHaveBeenCalled();
+  });
+
+  it("restores focus to the trash button after cancelling", async () => {
+    // MINOR 1. Radix only returns focus if the button is the DialogTrigger; opening via a manual
+    // setOpen leaves focus on the document body, which strands keyboard users mid-table.
+    const user = userEvent.setup();
+    renderList([customPermission]);
+    const button = trash();
+
+    await user.click(button);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it("does not disable one row's confirm button because another row is archiving", async () => {
+    // C4 for permissions, mirroring the roles suite. The hook-call count alone would pass even if
+    // every row read the same pending flag.
+    archivePending.perCall = [true, false];
+    const other: IPermission = { ...customPermission, itemId: "perm-other", name: "Manage Users" };
+    const user = userEvent.setup();
+    render(<PermissionsList permissions={[customPermission, other]} isLoading={false} />);
+
+    await user.click(trash("Manage Users"));
+    const confirm = screen.getByRole("button", { name: "Archive" }) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(false);
+    expect(screen.queryByRole("button", { name: "Archiving..." })).toBeNull();
+  });
+
+  it("archives on confirm, toasts success and closes the dialog", async () => {
+    // H1 in full: the call alone said nothing about what the user sees or whether the dialog goes.
+    const user = userEvent.setup();
+    renderList([customPermission]);
+    await user.click(trash());
+    await user.click(screen.getByRole("button", { name: "Archive" }));
+
+    expect(archivePermission).toHaveBeenCalledWith("perm-custom");
+    expect(successToast).toHaveBeenCalled();
+    expect(errorToast).not.toHaveBeenCalled();
+    expect(screen.queryByText("Archive this permission?")).toBeNull();
+  });
+
+  it("never navigates from the trash button, the dialog or its cancel", async () => {
+    // H6. This list's Edit is a bare Link and the row itself navigates, so the wrapper has to
+    // stop propagation -- including for the portalled dialog's own buttons.
+    const user = userEvent.setup();
+    renderList([customPermission]);
+    await user.click(trash());
+    expect(navigate).not.toHaveBeenCalled();
+    await user.click(screen.getByText("Archive this permission?"));
+    expect(navigate).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("gives every row its own archive mutation", () => {
+    // C4, same reasoning as the roles list.
+    useDeletePermissionSpy.mockClear();
+    renderList([customPermission, builtInPermission]);
+    expect(useDeletePermissionSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows the pending label while archiving", async () => {
+    // C3
+    archivePending.value = true;
+    const user = userEvent.setup();
+    renderList([customPermission]);
+    await user.click(trash());
+    expect(
+      (screen.getByRole("button", { name: "Archiving..." }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("renders no archive actions in the empty state", () => {
+    // C5
+    render(<PermissionsList permissions={[]} isLoading={false} />);
+    expect(screen.getByText("No permission found. Please create new permission.")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Archive permission/ })).toBeNull();
   });
 });

--- a/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions-list.tsx
+++ b/client/app/cross-modules/idp/iam/modules/permission-management/permissions/permissions-list.tsx
@@ -20,6 +20,8 @@ import {
   ResourceType,
 } from "@blocks-idp/iam/models/permission";
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { useDeletePermission } from "@blocks-idp/iam/hooks/use-permission";
+import { ArchiveAction } from "@blocks-idp/iam/components/archive-action";
 import { Pencil } from "lucide-react";
 import { useMemo } from "react";
 import { Link, useNavigate } from "react-router";
@@ -42,6 +44,52 @@ export const PermissionSeverityBadge = ({ severity }: { severity: PermissionSeve
     <Badge variant={config.variant} className={cn(config.className, config.bg)}>
       {config.label}
     </Badge>
+  );
+};
+/**
+ * Actions for one permission row.
+ *
+ * Same reasoning as the roles list: the mutation lives here so `isPending` is per row, and
+ * stopPropagation is on the wrapper because the row navigates on click and the dialog's own
+ * clicks bubble through the component tree despite rendering in a portal.
+ *
+ * The Archive action is shown for every row. Archiving a permission requires the caller to be
+ * in the default organization, but no client-side signal for that exists, so a rejection is
+ * surfaced as a mapped toast rather than the action being hidden.
+ */
+const PermissionRowActions = ({ row }: { row: IPermission }) => {
+  const { mutateAsync, isPending } = useDeletePermission();
+  const scoped = useScopedPath();
+
+  return (
+    <div
+      className="flex"
+      role="presentation"
+      onClick={(event) => event.stopPropagation()}
+    >
+      {/* The Link is scoped, not the hard-coded /app/iam path it used to carry: the row's own
+          onClick navigated via scoped() and picked up the tenant prefix, and the wrapper above
+          now stops that click from ever reaching the row. */}
+      {!row.isBuiltIn && (
+        <Link to={scoped(`iam/permission-detail/${row.itemId}`)}>
+          <Button
+            size="icon"
+            className="rounded-full"
+            variant="ghost"
+            aria-label={`Edit permission ${row.name}`}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+        </Link>
+      )}
+      <ArchiveAction
+        entity="permission"
+        name={row.name}
+        itemId={row.itemId}
+        archive={mutateAsync}
+        isPending={isPending}
+      />
+    </div>
   );
 };
 export const PermissionsList = ({ permissions, isLoading }: PermissionTableProps) => {
@@ -217,17 +265,7 @@ export const PermissionsList = ({ permissions, isLoading }: PermissionTableProps
       {
         id: "actions",
         enableHiding: false,
-        cell: ({ row }) => (
-          <div className="flex">
-            {!row.original.isBuiltIn && (
-              <Link to={`/app/iam/permission-detail/${row.original.itemId}`}>
-                <Button size="icon" className="rounded-full" variant="ghost">
-                  <Pencil className="h-4 w-4" />
-                </Button>
-              </Link>
-            )}
-          </div>
-        ),
+        cell: ({ row }) => <PermissionRowActions row={row.original} />,
       },
     ],
     [setSortQueryParams, sortQueryParams],
@@ -235,6 +273,9 @@ export const PermissionsList = ({ permissions, isLoading }: PermissionTableProps
   const table = useReactTable({
     data: permissions,
     columns,
+    // Row identity by itemId rather than the default array index -- see the note on the roles
+    // table: correct per-row identity, not a fix for an observed wrong-row bug.
+    getRowId: (row) => row.itemId,
     getCoreRowModel: getCoreRowModel(),
   });
   if (isLoading) return <LoadingSkelton />;

--- a/client/app/cross-modules/idp/iam/modules/role-management/roles/roles-list.test.tsx
+++ b/client/app/cross-modules/idp/iam/modules/role-management/roles/roles-list.test.tsx
@@ -46,6 +46,28 @@ vi.mock("@/components/filter-toolbar", () => ({
   },
 }));
 
+const successToast = vi.fn();
+const errorToast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({
+  showSuccessToast: (...a: unknown[]) => successToast(...a),
+  showErrorToast: (...a: unknown[]) => errorToast(...a),
+}));
+
+const archiveRole = vi.fn();
+const archivePending = { value: false, perCall: [] as boolean[] };
+const useDeleteRoleSpy = vi.fn();
+vi.mock("@blocks-idp/iam/hooks/use-roles", () => ({
+  useDeleteRole: () => {
+    useDeleteRoleSpy();
+    // perCall lets a test give each row its own pending value, which is the only way to observe
+    // whether the state is really per row rather than shared.
+    const pending = archivePending.perCall.length
+      ? (archivePending.perCall.shift() ?? false)
+      : archivePending.value;
+    return { mutateAsync: archiveRole, isPending: pending };
+  },
+}));
+
 vi.mock("../update-role/update-role", () => ({
   UpdateRole: ({ role }: { role: { name: string } }) => (
     <div data-testid="update-role-dialog">Editing {role.name}</div>
@@ -54,6 +76,7 @@ vi.mock("../update-role/update-role", () => ({
 
 import { RolesList } from "./roles-list";
 import { IRole } from "@blocks-idp/iam/models/role";
+import { ARCHIVE_ERROR_MESSAGES } from "@blocks-idp/iam/constants/archive-error-messages";
 
 const role = {
   itemId: "role-1",
@@ -80,13 +103,18 @@ describe("RolesList", () => {
   });
 
   it("renders loading skeletons and no table while loading", () => {
+    // C5. "No table" alone is satisfied by `return null`; the skeleton and its row count are what
+    // actually say the loading state renders as it does today.
     const { container } = render(<RolesList roles={[]} isLoading />);
     expect(container.querySelector("table")).toBeNull();
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(5);
   });
 
   it("shows the empty-state message for no roles", () => {
-    render(<RolesList roles={[]} isLoading={false} />);
+    const { container } = render(<RolesList roles={[]} isLoading={false} />);
     expect(screen.getByText("No roles found. Please create new roles.")).toBeTruthy();
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(0);
+    expect(screen.queryByRole("button", { name: /^Archive role/ })).toBeNull();
   });
 
   it("renders role rows with name, slug, permission count and description", () => {
@@ -108,11 +136,229 @@ describe("RolesList", () => {
     const user = userEvent.setup();
     render(<RolesList roles={[role]} isLoading={false} />);
     expect(screen.queryByTestId("update-role-dialog")).toBeNull();
-    // The only button in a row is the edit (Pencil) action.
-    await user.click(screen.getByRole("button"));
+    // There are two actions per row now, so select the edit button by its accessible name
+    // rather than by being the only button.
+    await user.click(screen.getByRole("button", { name: "Edit role Administrator" }));
     expect(screen.getByTestId("update-role-dialog")).toBeTruthy();
     expect(screen.getByText("Editing Administrator")).toBeTruthy();
     // Editing must not trigger row navigation.
     expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("RolesList archive action", () => {
+  const renderList = (roles: IRole[]) => render(<RolesList roles={roles} isLoading={false} />);
+  const trash = (name = "Administrator") =>
+    screen.getByRole("button", { name: `Archive role ${name}` });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    archivePending.value = false;
+    archivePending.perCall = [];
+    archiveRole.mockResolvedValue({ isSuccess: true });
+  });
+
+  it("renders an archive action for a normal role", () => {
+    renderList([role]);
+    expect(trash()).toBeTruthy();
+  });
+
+  it("hides the archive action for a role copied from the default organization", () => {
+    // H3
+    renderList([{ ...role, createdFromDefault: true }]);
+    expect(screen.queryByRole("button", { name: "Archive role Administrator" })).toBeNull();
+  });
+
+  it("opens a confirm dialog without sending a request", async () => {
+    // H4
+    const user = userEvent.setup();
+    renderList([role]);
+    await user.click(trash());
+    expect(screen.getByText("Archive this role?")).toBeTruthy();
+    expect(archiveRole).not.toHaveBeenCalled();
+  });
+
+  it("cancels without sending a request", async () => {
+    // H5
+    const user = userEvent.setup();
+    renderList([role]);
+    await user.click(trash());
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(archiveRole).not.toHaveBeenCalled();
+  });
+
+  it("archives on confirm, toasts success and closes", async () => {
+    // H2
+    const user = userEvent.setup();
+    renderList([role]);
+    await user.click(trash());
+    await user.click(screen.getByRole("button", { name: "Archive" }));
+
+    expect(archiveRole).toHaveBeenCalledWith("role-1");
+    expect(successToast).toHaveBeenCalled();
+    expect(errorToast).not.toHaveBeenCalled();
+    expect(screen.queryByText("Archive this role?")).toBeNull();
+  });
+
+  it("toasts the mapped reason on rejection and keeps the dialog open", async () => {
+    // C1. A rejection arrives thrown, so a handler written as `if (!res.isSuccess)` would fall
+    // through to the success path -- this is the assertion that catches that.
+    archiveRole.mockRejectedValue(
+      Object.assign(new Error("bad request"), {
+        errors: { dependency: "Role_Has_Child_Roles" },
+      }),
+    );
+    const user = userEvent.setup();
+    renderList([role]);
+    await user.click(trash());
+    await user.click(screen.getByRole("button", { name: "Archive" }));
+
+    expect(successToast).not.toHaveBeenCalled();
+    // The raw dictionary and the map, not a pre-mapped array: showErrorToast does the lookup,
+    // and handing it an array would collapse to "An unexpected error occurred."
+    expect(errorToast).toHaveBeenCalledWith({
+      errors: { dependency: "Role_Has_Child_Roles" },
+      customMessages: ARCHIVE_ERROR_MESSAGES,
+    });
+    expect(screen.getByText("Archive this role?")).toBeTruthy();
+  });
+
+  it("handles a transport-style failure through the same path", async () => {
+    // C2. No special-cased branch: an error with no usable dictionary still produces copy.
+    archiveRole.mockRejectedValue(new TypeError("Failed to fetch"));
+    const user = userEvent.setup();
+    renderList([role]);
+    await user.click(trash());
+    await user.click(screen.getByRole("button", { name: "Archive" }));
+
+    expect(successToast).not.toHaveBeenCalled();
+    expect(errorToast).toHaveBeenCalledWith({
+      errors: "Something went wrong while archiving.",
+      customMessages: ARCHIVE_ERROR_MESSAGES,
+    });
+  });
+
+  it("never navigates from the trash button, the dialog or its cancel", async () => {
+    // H6. The row navigates on click and React events bubble through the component tree even
+    // though the dialog is portalled, so the dialog's own buttons are checked too.
+    const user = userEvent.setup();
+    renderList([role]);
+    await user.click(trash());
+    expect(navigate).not.toHaveBeenCalled();
+
+    // Confirm: the click that both mutates and could bubble to the row.
+    await user.click(screen.getByRole("button", { name: "Archive" }));
+    expect(navigate).not.toHaveBeenCalled();
+
+    // And Cancel on a freshly opened dialog.
+    await user.click(trash());
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("drops the open dialog rather than retargeting it when the list changes underneath", async () => {
+    // The dangerous shape here would be a row component reused with a stale open=true and a new
+    // itemId, so Confirm archives a role the user never picked. Measured behaviour is the safe
+    // one: the row remounts and the dialog closes with no archive call. Asserted so that a
+    // regression to a reused-and-still-open dialog fails here instead of in production.
+    const other: IRole = { ...role, itemId: "role-other", name: "Auditor" };
+    const user = userEvent.setup();
+    const { rerender } = render(<RolesList roles={[other, role]} isLoading={false} />);
+
+    await user.click(screen.getByRole("button", { name: "Archive role Administrator" }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    // A refetch drops the other row.
+    rerender(<RolesList roles={[role]} isLoading={false} />);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(archiveRole).not.toHaveBeenCalled();
+  });
+
+  it("closes the confirmation on any parent re-render (known limitation)", async () => {
+    // Documents real behaviour rather than desired behaviour, so it fails loudly if either
+    // changes. Root cause is outside this ticket: useSortQueryParams returns a fresh
+    // sortQueryParams object every render, which invalidates the columns useMemo, which gives
+    // flexRender a new cell function -- a new component type, so the row subtree remounts and the
+    // dialog state goes with it. A background refetch therefore dismisses an open confirmation.
+    // Benign (nothing is archived, the user re-clicks) but worth fixing where sortQueryParams is
+    // memoised, which would also make this assertion flip.
+    const user = userEvent.setup();
+    const { rerender } = render(<RolesList roles={[role]} isLoading={false} />);
+
+    await user.click(screen.getByRole("button", { name: "Archive role Administrator" }));
+    expect(document.querySelector('[role="dialog"]')).toBeTruthy();
+
+    rerender(<RolesList roles={[role]} isLoading={false} />);
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(archiveRole).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate when the trash button is reached by keyboard", async () => {
+    // Enter on a button dispatches a click, so the same stopPropagation covers the keyboard path.
+    // Worth pinning: this is why there is no separate onKeyDown guard on the actions cell.
+    const user = userEvent.setup();
+    renderList([role]);
+
+    await user.tab();
+    await user.tab();
+    await user.keyboard("{Enter}");
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("gives every row its own archive mutation", () => {
+    // C4, part one: a hoisted hook would be called once for the whole list.
+    useDeleteRoleSpy.mockClear();
+    renderList([role, { ...role, itemId: "role-2", name: "Auditor" }]);
+    expect(useDeleteRoleSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not disable one row's confirm button because another row is archiving", async () => {
+    // C4, part two -- the assertion that actually matters. Row one is mid-archive, row two is
+    // idle: row two's confirm must still be usable. Counting hook calls alone would pass even if
+    // both rows read the same pending flag.
+    archivePending.perCall = [true, false];
+    const user = userEvent.setup();
+    renderList([role, { ...role, itemId: "role-2", name: "Auditor" }]);
+
+    await user.click(trash("Auditor"));
+    const confirm = screen.getByRole("button", { name: "Archive" }) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(false);
+    expect(screen.queryByRole("button", { name: "Archiving..." })).toBeNull();
+  });
+
+  it("shows the pending label while archiving", async () => {
+    // C3
+    archivePending.value = true;
+    const user = userEvent.setup();
+    renderList([role]);
+    await user.click(trash());
+    expect((screen.getByRole("button", { name: "Archiving..." }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders no archive actions in the empty state", () => {
+    // C5
+    render(<RolesList roles={[]} isLoading={false} />);
+    expect(screen.getByText("No roles found. Please create new roles.")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Archive role/ })).toBeNull();
+  });
+
+  it("keeps the edit dialog and the archive dialog independent", async () => {
+    // C6, both directions -- proving only one of them would leave the other regression open.
+    const user = userEvent.setup();
+    const { unmount } = renderList([role]);
+
+    await user.click(trash());
+    expect(screen.getByText("Archive this role?")).toBeTruthy();
+    expect(screen.queryByTestId("update-role-dialog")).toBeNull();
+    unmount();
+
+    renderList([role]);
+    await user.click(screen.getByRole("button", { name: "Edit role Administrator" }));
+    expect(screen.getByTestId("update-role-dialog")).toBeTruthy();
+    expect(screen.queryByText("Archive this role?")).toBeNull();
   });
 });

--- a/client/app/cross-modules/idp/iam/modules/role-management/roles/roles-list.tsx
+++ b/client/app/cross-modules/idp/iam/modules/role-management/roles/roles-list.tsx
@@ -10,6 +10,8 @@ import {
   TableRow,
 } from "@/components/ui-kits/table/table";
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { useDeleteRole } from "@blocks-idp/iam/hooks/use-roles";
+import { ArchiveAction } from "@blocks-idp/iam/components/archive-action";
 import { Pencil } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { UpdateRole } from "../update-role/update-role";
@@ -29,6 +31,47 @@ const LoadingSkelton = () => (
     ))}
   </div>
 );
+/**
+ * Actions for one role row.
+ *
+ * The archive mutation is instantiated here rather than in the list so `isPending` is scoped to
+ * this row; a single hoisted hook would disable every other row's confirm button.
+ *
+ * stopPropagation sits on the wrapper, not just the buttons: the row navigates on click, and
+ * React events bubble through the component tree even though the dialog renders in a portal --
+ * so Cancel, Confirm and the overlay would otherwise navigate away too.
+ */
+const RoleRowActions = ({ row, onEdit }: { row: IRole; onEdit: (role: IRole) => void }) => {
+  const { mutateAsync, isPending } = useDeleteRole();
+
+  return (
+    <div
+      className="flex"
+      role="presentation"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <Button
+        size="icon"
+        className="rounded-full"
+        variant="ghost"
+        aria-label={`Edit role ${row.name}`}
+        onClick={() => onEdit(row)}
+      >
+        <Pencil className="h-4 w-4" />
+      </Button>
+      {!row.createdFromDefault && (
+        <ArchiveAction
+          entity="role"
+          name={row.name}
+          itemId={row.itemId}
+          archive={mutateAsync}
+          isPending={isPending}
+        />
+      )}
+    </div>
+  );
+};
+
 export const RolesList = ({ roles, isLoading }: RolesTableProps) => {
   const { sortQueryParams, setSortQueryParams } = useRolesSortQueryParams();
   const [selectedRole, setSelectedRole] = useState<IRole | null>(null);
@@ -102,21 +145,7 @@ export const RolesList = ({ roles, isLoading }: RolesTableProps) => {
       {
         id: "actions",
         enableHiding: false,
-        cell: ({ row }) => (
-          <div className="flex">
-            <Button
-              size="icon"
-              className="rounded-full"
-              variant="ghost"
-              onClick={(event) => {
-                event.stopPropagation();
-                setSelectedRole(row.original);
-              }}
-            >
-              <Pencil className="h-4 w-4" />
-            </Button>
-          </div>
-        ),
+        cell: ({ row }) => <RoleRowActions row={row.original} onEdit={setSelectedRole} />,
       },
     ],
     [sortHandler, sortQueryParams],
@@ -124,6 +153,11 @@ export const RolesList = ({ roles, isLoading }: RolesTableProps) => {
   const table = useReactTable({
     data: roles,
     columns,
+    // Row identity by itemId rather than the default array index, so the React key on each
+    // TableRow tracks the role and not the position. Measured: an open Archive dialog closes when
+    // the data changes either way, so this is not fixing a live wrong-row bug -- it is the
+    // correct identity for anything TanStack keys per row.
+    getRowId: (row) => row.itemId,
     getCoreRowModel: getCoreRowModel(),
   });
   const onRowClickHandler = (itemId: number | string) => {

--- a/client/app/cross-modules/idp/iam/services/archive-contract.test.tsx
+++ b/client/app/cross-modules/idp/iam/services/archive-contract.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getErrorMessage, handleErrorMessages } from "@/lib/error";
+import {
+  ARCHIVE_ERROR_MESSAGES,
+  normalizeArchiveErrors,
+} from "@blocks-idp/iam/constants/archive-error-messages";
+import { PERMISSION_ENDPOINTS, ROLE_ENDPOINTS } from "@blocks-idp/iam/constants/endpoint.constant";
+import { ArchiveAction } from "@blocks-idp/iam/components/archive-action";
+import { permissionService } from "./permission.service";
+import { roleService } from "./role.service";
+
+const errorToast = vi.fn();
+const successToast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({
+  // The real handleErrorMessages still runs, so the assertions below see the string the user
+  // would read rather than the arguments the component happened to pass -- which is what let the
+  // array-collapsing bug hide behind a green test.
+  showErrorToast: ({
+    errors,
+    customMessages,
+  }: {
+    errors: unknown;
+    customMessages?: Record<string, string>;
+  }) => {
+    errorToast(handleErrorMessages(errors as never, customMessages));
+  },
+  showSuccessToast: () => successToast(),
+}));
+
+/**
+ * Contract tests for the archive endpoints.
+ *
+ * These live in their own file **without** the `vi.mock("@/lib/http/http-client")` that both
+ * service suites hoist: with that mock in place a stubbed `fetch` never reaches the real
+ * `HttpClient`, so `throwIfNotOk` would not run and the normalisation this file exists to prove
+ * would go untested while appearing covered.
+ */
+describe("archive endpoint contract", () => {
+  const jsonResponse = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  const endpoints = [
+    {
+      name: "role",
+      call: (id: string) => roleService.deleteRole(id),
+      url: `${ROLE_ENDPOINTS.GET_ROLES}/role-1`,
+      id: "role-1",
+      code: "Role_Has_Child_Roles",
+      pascalCode: "Role_Already_Archived",
+    },
+    {
+      name: "permission",
+      call: (id: string) => permissionService.deletePermission(id),
+      url: `${PERMISSION_ENDPOINTS.GET_PERMISSIONS}/perm-1`,
+      id: "perm-1",
+      code: "Permission_Already_Archived",
+      pascalCode: "Permission_Not_Found",
+    },
+  ];
+
+  it.each(endpoints)("$name: issues a DELETE to exactly the by-id route", async (e) => {
+    // Full-URL equality, not a substring: `toContain("/iam/roles/role-1")` would also pass for a
+    // wrong host or a doubled path segment.
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { isSuccess: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await e.call(e.id);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(e.url);
+    expect(init?.method).toBe("DELETE");
+  });
+
+  const archiveAndCatch = async (e: (typeof endpoints)[number]) => {
+    try {
+      await e.call(e.id);
+      return undefined;
+    } catch (error) {
+      return error;
+    }
+  };
+
+  it.each(endpoints)("$name: carries a 400's reason code through to mapped copy", async (e) => {
+    // The whole chain: fetch -> throwIfNotOk -> HttpError.errors -> normalize -> message map.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse(400, { isSuccess: false, errors: { dependency: e.code } }),
+      ),
+    );
+
+    const errors = normalizeArchiveErrors(await archiveAndCatch(e));
+
+    expect(errors).toEqual({ dependency: e.code });
+    expect(getErrorMessage(errors!, ARCHIVE_ERROR_MESSAGES)).toEqual([
+      ARCHIVE_ERROR_MESSAGES[e.code],
+    ]);
+  });
+
+  it.each(endpoints)("$name: carries the code through a PascalCase body", async (e) => {
+    // throwIfNotOk only recognises a lowercase `errors`, so a PascalCase body arrives with the
+    // whole response object attached instead. ASP.NET Core's defaults give lowercase and
+    // blocks-iam sets no naming policy, but that is a separate repo on a separate deploy.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse(400, { isSuccess: false, Errors: { archived: e.pascalCode } }),
+      ),
+    );
+
+    const errors = normalizeArchiveErrors(await archiveAndCatch(e));
+
+    expect(errors).toEqual({ archived: e.pascalCode });
+    expect(getErrorMessage(errors!, ARCHIVE_ERROR_MESSAGES)).toEqual([
+      ARCHIVE_ERROR_MESSAGES[e.pascalCode],
+    ]);
+  });
+
+  describe("what the user actually sees", () => {
+    // C2 and C7 end to end: ArchiveAction driven by the real service over a stubbed socket, with
+    // the real handleErrorMessages. Recomputing a message in the test would have re-implemented
+    // the component's own logic and missed the array-collapsing bug entirely.
+    const renderAction = () =>
+      render(
+        <ArchiveAction
+          entity="role"
+          name="Administrator"
+          itemId="role-1"
+          archive={(id) => roleService.deleteRole(id) as Promise<unknown>}
+          isPending={false}
+        />,
+      );
+
+    const confirm = async () => {
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: "Archive role Administrator" }));
+      await user.click(screen.getByRole("button", { name: "Archive" }));
+    };
+
+    it("shows the mapped copy for a rejected archive", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse(400, {
+            isSuccess: false,
+            errors: { dependency: "Role_Has_Child_Roles" },
+          }),
+        ),
+      );
+
+      renderAction();
+      await confirm();
+
+      // An array, because showErrorToast renders one line per mapped message.
+      expect(errorToast).toHaveBeenCalledWith([ARCHIVE_ERROR_MESSAGES.Role_Has_Child_Roles]);
+      expect(successToast).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the raw code when the backend adds a reason", async () => {
+      // C7: drift degrades to the code rather than a blank or generic toast.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse(400, { isSuccess: false, errors: { forbidden: "Some_Future_Code" } }),
+        ),
+      );
+
+      renderAction();
+      await confirm();
+
+      expect(errorToast).toHaveBeenCalledWith(["Some_Future_Code"]);
+    });
+
+    it("shows the archive fallback rather than a blank toast for an empty reason", async () => {
+      // A dictionary with a blank value is a shape the backend should not send, but it used to
+      // render one empty line in the toast, which reads as a silent failure.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse(400, { isSuccess: false, errors: { dependency: "" } }),
+        ),
+      );
+
+      renderAction();
+      await confirm();
+
+      expect(errorToast).toHaveBeenCalledWith("Something went wrong.");
+    });
+
+    it("maps reason codes that arrive as an array", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse(400, {
+            isSuccess: false,
+            errors: { dependency: ["Role_Has_Child_Roles", "Role_Has_Active_User_Assignments"] },
+          }),
+        ),
+      );
+
+      renderAction();
+      await confirm();
+
+      expect(errorToast).toHaveBeenCalledWith([
+        `${ARCHIVE_ERROR_MESSAGES.Role_Has_Child_Roles}, ${ARCHIVE_ERROR_MESSAGES.Role_Has_Active_User_Assignments}`,
+      ]);
+    });
+
+    it("shows a real message on a transport failure", async () => {
+      // C2. Rejecting a mocked mutateAsync with a bare Error would skip the client's own
+      // normalisation, which is exactly the path this criterion is about.
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+      renderAction();
+      await confirm();
+
+      expect(errorToast).toHaveBeenCalledWith("Something went wrong while archiving.");
+      expect(successToast).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/app/cross-modules/idp/iam/services/permission.service.ts
+++ b/client/app/cross-modules/idp/iam/services/permission.service.ts
@@ -14,6 +14,7 @@ import {
   UpdatePermissionResponse,
 } from "@blocks-idp/iam/models/permission";
 import { PERMISSION_ENDPOINTS } from "../constants/endpoint.constant";
+import { ArchiveResponse } from "../constants/archive-error-messages";
 
 export class PermissionService {
   getPermissions(
@@ -28,6 +29,17 @@ export class PermissionService {
   // via the X-Blocks-Key header, and the hook gates the request on a selected project.
   getPermissionsSeverity(): Promise<IGetPermissionsSeverityResponse> {
     return http.get(`${PERMISSION_ENDPOINTS.GET_PERMISSIONS_GROUP_BY_SEVERITY}`, undefined, {
+      absoluteUrl: true,
+    });
+  }
+
+  /**
+   * Archives a permission. Soft delete on the backend. Note the caller must be in the default
+   * organization for this to succeed -- there is no client-side signal for that, so the rejection
+   * is surfaced as a mapped toast rather than the action being hidden.
+   */
+  deletePermission(id: string): Promise<ArchiveResponse> {
+    return http.delete(`${PERMISSION_ENDPOINTS.GET_PERMISSIONS}/${id}`, undefined, {
       absoluteUrl: true,
     });
   }

--- a/client/app/cross-modules/idp/iam/services/role.service.ts
+++ b/client/app/cross-modules/idp/iam/services/role.service.ts
@@ -10,6 +10,7 @@ import {
   UpdateRolePayload,
 } from "@blocks-idp/iam/models/role";
 import { ROLE_ENDPOINTS } from "../constants/endpoint.constant";
+import { ArchiveResponse } from "../constants/archive-error-messages";
 
 export class RoleService {
   getRoles(payload: GetRolesPayload): Promise<GetRolesResponse> {
@@ -36,6 +37,17 @@ export class RoleService {
       isSuccess: boolean;
       itemId: string;
     }>(ROLE_ENDPOINTS.UPDATE_ROLE, payload, undefined, { absoluteUrl: true });
+  }
+
+  /**
+   * Archives a role. Soft delete on the backend -- the document survives, so this is safe to
+   * expose from the list. Rejections arrive as a thrown HttpError carrying the reason code; see
+   * ARCHIVE_ERROR_MESSAGES.
+   */
+  deleteRole(id: string): Promise<ArchiveResponse> {
+    return http.delete(`${ROLE_ENDPOINTS.GET_ROLES}/${id}`, undefined, {
+      absoluteUrl: true,
+    });
   }
 
   setRoles(addSetRolesPayload: SetRoles): Promise<SetRoles> {

--- a/client/app/cross-modules/idp/test-utils/__mocks__/mock-factories.ts
+++ b/client/app/cross-modules/idp/test-utils/__mocks__/mock-factories.ts
@@ -121,6 +121,7 @@ export const mockRoleServiceFactory = () => ({
     addRole: vi.fn(),
     updateRole: vi.fn(),
     setRoles: vi.fn(),
+    deleteRole: vi.fn(),
   },
 });
 
@@ -130,6 +131,7 @@ export const mockPermissionServiceFactory = () => ({
     getPermissionById: vi.fn(),
     addPermission: vi.fn(),
     updatePermission: vi.fn(),
+    deletePermission: vi.fn(),
     getResourceGroup: vi.fn(),
   },
 });
@@ -164,6 +166,7 @@ export const mockIamServiceFactory = () => ({
       getPermissions: vi.fn(),
       getPermissionById: vi.fn(),
       addPermission: vi.fn(),
+      deletePermission: vi.fn(),
       updatePermission: vi.fn(),
       getResourceGroup: vi.fn(),
     },

--- a/client/app/lib/error.test.ts
+++ b/client/app/lib/error.test.ts
@@ -68,3 +68,64 @@ describe("lib/error", () => {
     });
   });
 });
+
+describe("getErrorMessage value-first lookup", () => {
+  // Server errors that carry a reason code put it in the VALUE and reuse a small set of category
+  // keys, so a key-only lookup cannot tell those reasons apart.
+  const map = {
+    Role_Has_Child_Roles: "Archive the child roles first.",
+    forbidden: "Not allowed.",
+  };
+
+  it("prefers the value when both the value and the key are mapped", () => {
+    expect(getErrorMessage({ forbidden: "Role_Has_Child_Roles" }, map)).toEqual([
+      "Archive the child roles first.",
+    ]);
+  });
+
+  it("distinguishes two reasons that share one category key", () => {
+    // This is the whole point: key-first would return the same message for both.
+    const codes = {
+      Role_Has_Child_Roles: "Archive the child roles first.",
+      Can_Not_Archive_Default_Copied_Role: "Copied from the default organization.",
+    };
+    expect(getErrorMessage({ forbidden: "Role_Has_Child_Roles" }, codes)).toEqual([
+      "Archive the child roles first.",
+    ]);
+    expect(getErrorMessage({ forbidden: "Can_Not_Archive_Default_Copied_Role" }, codes)).toEqual([
+      "Copied from the default organization.",
+    ]);
+  });
+
+  it("still falls back to the key so existing callers keep working", () => {
+    expect(getErrorMessage({ forbidden: "Some_Unmapped_Code" }, map)).toEqual(["Not allowed."]);
+  });
+
+  it("falls back to the raw value when neither is mapped", () => {
+    expect(getErrorMessage({ dependency: "Some_New_Backend_Code" }, map)).toEqual([
+      "Some_New_Backend_Code",
+    ]);
+  });
+
+  it("skips blank values rather than rendering an empty message", () => {
+    // { dependency: "" } used to produce a single blank line in the toast.
+    expect(getErrorMessage({ dependency: "" }, { Some_Code: "mapped" })).toBe("Something went wrong.");
+    expect(getErrorMessage({ a: "   ", b: "real" })).toEqual(["real"]);
+  });
+
+  it("maps each element of an array value", () => {
+    // Joining first meant a string[] of reason codes never hit the map.
+    expect(getErrorMessage({ dependency: ["A_Code", "B_Code"] }, { A_Code: "first", B_Code: "second" })).toEqual([
+      "first, second",
+    ]);
+  });
+
+  it("still joins array values when nothing maps, as before", () => {
+    expect(getErrorMessage({ dependency: ["one", "two"] })).toEqual(["one, two"]);
+  });
+
+  it("drops blank array elements", () => {
+    expect(getErrorMessage({ dependency: ["", "  ", "real"] })).toEqual(["real"]);
+    expect(getErrorMessage({ dependency: ["", "  "] })).toBe("Something went wrong.");
+  });
+});

--- a/client/app/lib/error.ts
+++ b/client/app/lib/error.ts
@@ -30,15 +30,31 @@ export const getErrorMessage = (
   for (const key in error) {
     const value = error[key];
 
+    // Value before key. Server errors that carry a reason code put it in the value and reuse a
+    // small set of category keys, so a key lookup cannot tell those reasons apart -- "forbidden"
+    // alone covers five different ones on the IAM archive endpoints. Key lookup is kept as the
+    // fallback so callers that map by key are unaffected.
+    if (typeof value === "string" && messageMap[value]) {
+      messages.push(messageMap[value]);
+      continue;
+    }
+
     if (messageMap[key]) {
       messages.push(messageMap[key]);
       continue;
     }
 
     if (typeof value === "string") {
-      messages.push(value);
+      // A blank value used to be pushed verbatim, which rendered an empty toast line. Skipping it
+      // lets the "Something went wrong." fallback below take over.
+      if (value.trim().length > 0) messages.push(value);
     } else if (Array.isArray(value) && value.length > 0) {
-      messages.push(value.join(", "));
+      // Map each element, not the joined string: ASP.NET dictionaries can carry the reason codes
+      // as a string[], and joining first meant the map never saw them.
+      const mapped = value
+        .filter((item) => typeof item === "string" && item.trim().length > 0)
+        .map((item) => messageMap[item] ?? item);
+      if (mapped.length) messages.push(mapped.join(", "));
     }
   }
 


### PR DESCRIPTION
Closes #472 — https://github.com/SELISEdigitalplatforms/blocks-os/issues/472

Adds a per-row **Archive** action with a confirmation dialog to the IAM **Roles** and **Permissions** lists, consuming the two soft-delete endpoints delivered in blocks-iam #454 (permissions, PR #455) and #456 (roles, PR #457), both merged.

## What a reviewer should look at

Three things in this area are easy to get wrong, and each is load-bearing:

**A rejected archive is thrown, not returned.** `throwIfNotOk` raises `HttpError` on any non-ok response, and the controller returns `BadRequest` for every rejection — so `const res = await mutate(); if (!res.isSuccess)` is unreachable and would fire a **success toast on every rejection**, invisibly to the type checker. The handler is `try`/`catch`. The resolved-failure guard still exists, for a `200 {isSuccess:false}`, but it lives in `mutationFn` rather than the component: `mutateAsync` only settles after react-query has classified the result and run `onSuccess`, so a component-level check would show the right toast while the list had already refetched.

**`showErrorToast` does the mapping itself.** It calls `handleErrorMessages(errors, customMessages)` internally, and that collapses **any array** to `"An unexpected error occurred."`. Pre-mapping with `getErrorMessage` produced a `string[]`, so the mapped copy was computed and then discarded — the user saw the generic string. The raw dictionary and `ARCHIVE_ERROR_MESSAGES` now go in unmapped.

**`getErrorMessage` matches on the value before the key.** The backend keys its error dictionary by *category* — `forbidden`, `dependency`, `archived`, `ItemId` — and puts the reason code in the *value*. `forbidden` alone covers five distinct reasons across the two endpoints, so a key lookup cannot tell them apart. Key lookup is retained as the fallback; no production caller passes `customMessages` today except this feature, so no existing behaviour changes.

## Also in this PR

- `ARCHIVE_ERROR_MESSAGES` covers **all 11** backend reason codes, enumerated from the merged blocks-iam source rather than from prose, and pinned by an equality assertion so backend drift fails a test rather than showing a raw code.
- `getErrorMessage` now skips blank values (which used to render an empty toast line) and maps each element of an array value instead of joining first.
- The permissions Edit link is now `scoped(...)`. It had been picking up the tenant prefix only because the click also bubbled to the row's `navigate(scoped(...))`, which the new actions-cell `stopPropagation` cuts off.
- `IRole.isArchived` added as optional — required breaks `tsc -b`, since two typed constructors omit it.

## Known limitation, carried from the ticket (C8/A3)

Permission archive requires the caller's organization to be `default`. No client-side signal for default-org membership exists anywhere in `client/app`, so the action **cannot** be hidden: a non-default-org admin sees a Trash button that can never succeed on any row. The best available behaviour without a new backend signal is the clearly mapped rejection toast, which is what this implements.

## Known limitation found while building this

An open confirmation dialog is dismissed by **any** re-render of the list — including a background refetch. Root cause is outside this ticket: `useSortQueryParams` returns a fresh `sortQueryParams` object every render, which invalidates the `columns` memo, which hands `flexRender` a new cell function — a new component type, so the row subtree remounts. It is benign (nothing is archived; the user re-clicks) and it is pinned by a test named as a known limitation, so memoising `sortQueryParams` later has to flip that assertion deliberately. Fixing it here would mean changing a shared component used by many other lists.

## Verification

- **Tests:** 3193 passed, 4 failed. All 4 failures are pre-existing and unrelated (2 collection errors from SVG asset resolution in `repository-selection-modal` and `render-provider`; 4 assertions in `organization-permissions-field`). Confirmed against a `git stash push -u` clean baseline.
- **Coverage on added lines only**, intersecting lcov with `git diff -U0` — whole-file percentages are meaningless here, since `use-roles.ts` is mostly untouched hooks: `archive-action.tsx` 12/12, `archive-error-messages.ts` 10/10, `use-roles.ts` 8/8, `use-permission.ts` 8/8, `roles-list.tsx` 7/7, `permissions-list.tsx` 7/7, `error.ts` 8/8. **100%**, against a bar of 80%.
- `tsc -b` clean. eslint adds no new problems.
- **14 mutation probes, 14 killed** — including re-introducing the pre-mapped array, dropping the empty-dictionary guard, unscoping the Edit link, moving the resolved-failure guard out of `mutationFn`, removing the actions-cell `stopPropagation`, firing a success toast on failure, showing Archive on default-copied roles, reverting the value-before-key lookup, opening the dialog without `DialogTrigger`, and replacing the loading skeleton with `null`.

Two review cycles on the plan and two on the code, no unresolved critical findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
