### PR TITLE
[#471] Paginate Domains and Repositories sections on the Dashboard

### DIFF
--- a/client/app/pages/dashboard/components/dashboard.constant.ts
+++ b/client/app/pages/dashboard/components/dashboard.constant.ts
@@ -1,0 +1,3 @@
+/** Dashboard tables show at most this many rows per page.
+ *  Shared by the Domains and Repositories sections so the two cannot drift apart. */
+export const DASHBOARD_TABLE_PAGE_SIZE = 5;

--- a/client/app/pages/dashboard/components/domain/domain-table.test.tsx
+++ b/client/app/pages/dashboard/components/domain/domain-table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -189,5 +189,159 @@ describe("DomainTable", () => {
     await waitFor(() =>
       expect(showErrorToast).toHaveBeenCalledWith({ errors: "Failed to delete domain" }),
     );
+  });
+});
+
+
+// ─── Pagination (#471) ────────────────────────────────────────────────────────
+
+const manyDomains = (count: number) =>
+  Array.from({ length: count }, (_item, index) => ({
+    domain: `domain-${index + 1}.com`,
+    isDomainVerified: false,
+    cookieDomain: `.domain-${index + 1}.com`,
+  })) as unknown as IDomain[];
+
+const names = (count: number, from = 1) =>
+  Array.from({ length: count }, (_item, index) => `domain-${from + index}.com`);
+
+/** The first cell of every rendered body row — the domain column. */
+const visibleDomains = () =>
+  Array.from(document.querySelectorAll("tbody tr")).map(
+    (row) => row.querySelector("td")?.textContent?.trim() ?? "",
+  );
+
+/** The pagination landmark. Asserting on it also proves the control is labelled. */
+const paginationNav = () => screen.getByRole("navigation", { name: /pagination/i });
+
+const pageIndicator = () => within(paginationNav()).getByText(/^Page \d+ of \d+$/);
+
+/** The four navigation buttons, in the order the shared control renders them.
+ *  They are icon-only and carry no accessible name, so position is the only handle;
+ *  the length assertion makes a change in the shared control fail here loudly rather
+ *  than quietly clicking the wrong button. */
+const navButtons = () => {
+  const buttons = within(paginationNav()).getAllByRole("button") as HTMLButtonElement[];
+  expect(buttons).toHaveLength(4);
+  const [first, previous, next, last] = buttons;
+  return { first, previous, next, last };
+};
+
+describe("DomainTable pagination", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders only the first five of twelve domains", () => {
+    render(<DomainTable data={manyDomains(12)} />);
+    expect(visibleDomains()).toEqual(names(5));
+    expect(pageIndicator().textContent).toBe("Page 1 of 3");
+  });
+
+  it("moves to the next page", async () => {
+    const user = userEvent.setup();
+    render(<DomainTable data={manyDomains(12)} />);
+    await user.click(navButtons().next);
+    expect(visibleDomains()).toEqual(names(5, 6));
+    expect(pageIndicator().textContent).toBe("Page 2 of 3");
+  });
+
+  it("jumps to the last page, back one, and home again", async () => {
+    const user = userEvent.setup();
+    render(<DomainTable data={manyDomains(12)} />);
+
+    await user.click(navButtons().last);
+    expect(visibleDomains()).toEqual(names(2, 11));
+    expect(pageIndicator().textContent).toBe("Page 3 of 3");
+
+    await user.click(navButtons().previous);
+    expect(visibleDomains()).toEqual(names(5, 6));
+
+    await user.click(navButtons().first);
+    expect(visibleDomains()).toEqual(names(5));
+    expect(pageIndicator().textContent).toBe("Page 1 of 3");
+  });
+
+  it("cannot go back from the first page", () => {
+    render(<DomainTable data={manyDomains(12)} />);
+    const { first, previous } = navButtons();
+    expect(first.disabled).toBe(true);
+    expect(previous.disabled).toBe(true);
+  });
+
+  it("keeps exactly five domains on a single page", () => {
+    render(<DomainTable data={manyDomains(5)} />);
+    expect(visibleDomains()).toEqual(names(5));
+    expect(pageIndicator().textContent).toBe("Page 1 of 1");
+    const { next, last } = navButtons();
+    expect(next.disabled).toBe(true);
+    expect(last.disabled).toBe(true);
+  });
+
+  it("still shows a single-page control for fewer than five domains", () => {
+    // A `data.length >= 5` gate would hide the control here and pass every other case.
+    render(<DomainTable data={manyDomains(3)} />);
+    expect(visibleDomains()).toEqual(names(3));
+    expect(pageIndicator().textContent).toBe("Page 1 of 1");
+    const { next, last } = navButtons();
+    expect(next.disabled).toBe(true);
+    expect(last.disabled).toBe(true);
+  });
+
+  it("renders no pagination control at all when there are no domains", () => {
+    render(<DomainTable data={[]} />);
+    expect(screen.getByText("No domains configured yet.")).toBeTruthy();
+    // Never "Page 1 of 1" over an empty state.
+    expect(screen.queryByRole("navigation", { name: /pagination/i })).toBeNull();
+  });
+
+  it("clamps to the last page that still exists when the data shrinks", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<DomainTable data={manyDomains(12)} />);
+    await user.click(navButtons().last);
+    expect(pageIndicator().textContent).toBe("Page 3 of 3");
+
+    rerender(<DomainTable data={manyDomains(6)} />);
+
+    // TanStack queues its auto-reset in a microtask; flush it (and the render it
+    // would cause) so this assertion can actually see a page that moved.
+    await act(async () => {});
+
+    // Neither "Page 1 of 2" (an auto-reset to the start) nor "Page 3 of 2" (no clamp,
+    // blank body). Asserting only that rows render would accept the first of those.
+    expect(pageIndicator().textContent).toBe("Page 2 of 2");
+    expect(visibleDomains()).toEqual(names(1, 6));
+  });
+
+  it("keeps the current page when a refetch replaces the data", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<DomainTable data={manyDomains(12)} />);
+    await user.click(navButtons().next);
+    expect(pageIndicator().textContent).toBe("Page 2 of 3");
+
+    // A background refetch hands down an equal but brand-new array. Nothing the reader
+    // is looking at has changed, so the page must not move under them.
+    rerender(<DomainTable data={manyDomains(12)} />);
+
+    // TanStack queues its auto-reset in a microtask; flush it (and the render it
+    // would cause) so this assertion can actually see a page that moved.
+    await act(async () => {});
+
+    expect(pageIndicator().textContent).toBe("Page 2 of 3");
+    expect(visibleDomains()).toEqual(names(5, 6));
+  });
+
+  it("offers no rows-per-page selector", () => {
+    render(<DomainTable data={manyDomains(12)} />);
+    expect(screen.queryByText("Rows per page")).toBeNull();
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  it("fires a row action for the row shown on page two", async () => {
+    const user = userEvent.setup();
+    render(<DomainTable data={manyDomains(12)} />);
+    await user.click(navButtons().next);
+    // First visible row on page 2 is the sixth domain — an action wired to the raw
+    // data array instead of the row model would open the first one.
+    await user.click(screen.getAllByTitle("Validate CNAME")[0]);
+    expect(screen.getByTestId("cname-dialog").getAttribute("data-domain")).toBe("domain-6.com");
   });
 });

--- a/client/app/pages/dashboard/components/domain/domain-table.tsx
+++ b/client/app/pages/dashboard/components/domain/domain-table.tsx
@@ -5,10 +5,13 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
+  getPaginationRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import { Settings, ShieldCheck, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useLayoutEffect, useState } from "react";
+import { Pagination } from "@/components/ui-kits/pagination/pagination";
+import { DASHBOARD_TABLE_PAGE_SIZE } from "../dashboard.constant";
 import { DomainFormDialog } from "./domain-form-dialog";
 import { DomainAction } from "./domain.constant";
 import { showErrorToast, showSuccessToast } from "@seliseblocks/genesis-os/utils";
@@ -170,7 +173,23 @@ export const DomainTable = ({ data }: DomainTableProps) => {
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: DASHBOARD_TABLE_PAGE_SIZE } },
+    // A data change otherwise queues a reset of the page index back to the first page.
+    // That reset would race the clamp below and win, throwing a reader back to page 1 on
+    // every background refetch, so the index is kept and corrected explicitly instead.
+    autoResetPageIndex: false,
   });
+
+  const { pageIndex } = table.getState().pagination;
+  const lastPageIndex = Math.max(0, table.getPageCount() - 1);
+
+  // Deleting the last row of the last page leaves the index past the end of the data,
+  // which renders an empty table body. Clamp in a layout effect so that blank frame is
+  // never painted.
+  useLayoutEffect(() => {
+    if (pageIndex > lastPageIndex) table.setPageIndex(lastPageIndex);
+  }, [pageIndex, lastPageIndex, table]);
 
   return (
     <>
@@ -250,6 +269,20 @@ export const DomainTable = ({ data }: DomainTableProps) => {
           </tbody>
         </table>
       </div>
+
+      {/* Pagination — omitted entirely when there is nothing to page through, so the
+          empty state is not captioned "Page 1 of 1". No page-size selector: the size is
+          fixed at five. */}
+      {data.length > 0 && (
+        <nav aria-label="Domains pagination" className="mt-4 flex items-center md:justify-end">
+          <Pagination
+            page={pageIndex}
+            pageSize={DASHBOARD_TABLE_PAGE_SIZE}
+            totalCount={data.length}
+            onChange={(nextPageIndex) => table.setPageIndex(nextPageIndex)}
+          />
+        </nav>
+      )}
     </>
   );
 };

--- a/client/app/pages/dashboard/components/project/repo-list.test.tsx
+++ b/client/app/pages/dashboard/components/project/repo-list.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IEnvRepository, IProject } from "@seliseblocks/genesis-os/models";
+
+// The point of this file is the REAL ProjectRepoList: the synthetic parent in
+// repo-table.test.tsx proves the pattern, but only this proves the component that ships.
+const h = vi.hoisted(() => ({ isFetching: false, isLoading: false }));
+
+vi.mock("@/hooks/use-project", () => ({
+  useGetEnvRepositories: () => ({
+    data: { data: h.repositories, errors: null, isSuccess: true },
+    isLoading: h.isLoading,
+    isFetching: h.isFetching,
+  }),
+}));
+
+vi.mock("@seliseblocks/genesis-os", () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+  return {
+    Tooltip: Passthrough,
+    TooltipTrigger: Passthrough,
+    TooltipContent: Passthrough,
+    TooltipProvider: Passthrough,
+  };
+});
+
+vi.mock("@seliseblocks/genesis-os/components", () => ({
+  DashboardSectionCard: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <section>
+      <h2>{title}</h2>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock("@seliseblocks/genesis-os/utils", () => ({ formatFullDate: () => "FMT-DATE" }));
+vi.mock("../custom-domain/dialog", () => ({ SetCustomDomainDialog: () => null }));
+
+import { ProjectRepoList } from "./repo-list";
+
+const repositories = Array.from({ length: 12 }, (_item, index) => ({
+  repoName: `repo-${index + 1}`,
+  defaultDeploymentUrl: `repo-${index + 1}.default.dev`,
+  customDeploymentUrl: "",
+  lastDeploymentDate: "2024-06-01T10:00:00",
+})) as unknown as IEnvRepository[];
+
+// Assigned onto the hoisted holder so the mock factory (hoisted above this file's body)
+// can reach it.
+(h as unknown as { repositories: IEnvRepository[] }).repositories = repositories;
+
+const project = {
+  tenantId: "tenant-1",
+  environment: "dev",
+  applications: [],
+} as unknown as IProject;
+
+const paginationNav = () => screen.getByRole("navigation", { name: /pagination/i });
+const pageIndicator = () => within(paginationNav()).getByText(/^Page \d+ of \d+$/);
+const nextButton = () => {
+  const buttons = within(paginationNav()).getAllByRole("button") as HTMLButtonElement[];
+  expect(buttons).toHaveLength(4);
+  return buttons[2];
+};
+
+describe("ProjectRepoList", () => {
+  beforeEach(() => {
+    h.isFetching = false;
+    h.isLoading = false;
+    vi.clearAllMocks();
+  });
+
+  it("holds the reader's page across a background refetch", async () => {
+    // repo-list swaps the entire table for a skeleton while isFetching is true, which
+    // unmounts ProjectRepoTable. The page index lives here precisely so that survives.
+    const user = userEvent.setup();
+    const { rerender } = render(<ProjectRepoList project={project} isLoading={false} />);
+
+    await user.click(nextButton());
+    expect(pageIndicator().textContent).toBe("Page 2 of 3");
+
+    // isLoading stays FALSE: the hook's isFetching must be what selects the skeleton,
+    // otherwise dropping isFetchingEnvRepos from that gate would still pass this test.
+    h.isFetching = true;
+    rerender(<ProjectRepoList project={project} isLoading={false} />);
+    expect(screen.queryByRole("navigation", { name: /pagination/i })).toBeNull();
+
+    h.isFetching = false;
+    rerender(<ProjectRepoList project={project} isLoading={false} />);
+
+    expect(pageIndicator().textContent).toBe("Page 2 of 3");
+    expect(screen.getByText("repo-6")).toBeTruthy();
+    expect(screen.queryByText("repo-1")).toBeNull();
+  });
+
+  it("shows the first page on a fresh mount", () => {
+    render(<ProjectRepoList project={project} isLoading={false} />);
+    expect(pageIndicator().textContent).toBe("Page 1 of 3");
+    expect(screen.getByText("repo-1")).toBeTruthy();
+  });
+});

--- a/client/app/pages/dashboard/components/project/repo-list.tsx
+++ b/client/app/pages/dashboard/components/project/repo-list.tsx
@@ -2,6 +2,7 @@ import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { DashboardSectionCard } from "@seliseblocks/genesis-os/components";
 import { useGetEnvRepositories } from "@/hooks/use-project";
 import type { IProject } from "@seliseblocks/genesis-os/models";
+import { useState } from "react";
 import { ProjectRepoTable } from "./repo-table";
 
 export const ProjectRepoList = ({
@@ -12,6 +13,9 @@ export const ProjectRepoList = ({
   isLoading: boolean;
 }) => {
   const { applications } = project;
+  // Held here rather than in the table: the skeleton branch below unmounts the table on
+  // every background refetch, which would silently return a reader to the first page.
+  const [repoPageIndex, setRepoPageIndex] = useState(0);
   const {
     data: envRepositoriesResponse,
     isLoading: isLoadingEnvRepos,
@@ -44,6 +48,8 @@ export const ProjectRepoList = ({
         domains={applications}
         projectKey={project?.tenantId || ""}
         projectEnv={project?.environment || ""}
+        page={repoPageIndex}
+        onPageChange={setRepoPageIndex}
       />
     </DashboardSectionCard>
   );

--- a/client/app/pages/dashboard/components/project/repo-table.test.tsx
+++ b/client/app/pages/dashboard/components/project/repo-table.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
 import type { IEnvRepository } from "@seliseblocks/genesis-os/models";
 
 vi.mock("@seliseblocks/genesis-os/utils", () => ({
@@ -38,10 +39,23 @@ const repo = (over: Partial<IEnvRepository> = {}): IEnvRepository =>
     ...over,
   }) as IEnvRepository;
 
-const renderTable = (data: IEnvRepository[]) =>
-  render(
-    <ProjectRepoTable data={data} domains={[]} projectKey="pk" projectEnv="dev" />,
+/** Mirrors production: the page index lives in the parent (ProjectRepoList), because the
+ *  table itself is unmounted and remounted on every background refetch. */
+const RepoTableHarness = ({ data }: { data: IEnvRepository[] }) => {
+  const [page, setPage] = useState(0);
+  return (
+    <ProjectRepoTable
+      data={data}
+      domains={[]}
+      projectKey="pk"
+      projectEnv="dev"
+      page={page}
+      onPageChange={setPage}
+    />
   );
+};
+
+const renderTable = (data: IEnvRepository[]) => render(<RepoTableHarness data={data} />);
 
 describe("ProjectRepoTable", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -87,5 +101,186 @@ describe("ProjectRepoTable", () => {
     renderTable([repo({ customDeploymentUrl: "" })]);
     const editButton = screen.getByRole("button", { name: /edit custom domain/i });
     expect((editButton as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+
+// --- Pagination (#471) ------------------------------------------------------
+
+const manyRepos = (count: number) =>
+  Array.from({ length: count }, (_item, index) => repo({ repoName: `repo-${index + 1}` }));
+
+const repoNames = (count: number, from = 1) =>
+  Array.from({ length: count }, (_item, index) => `repo-${from + index}`);
+
+/** The first cell of every rendered body row - the repository name column. */
+const visibleRepos = () =>
+  Array.from(document.querySelectorAll("tbody tr")).map(
+    (row) => row.querySelector("td")?.textContent?.trim() ?? "",
+  );
+
+/** The pagination landmark. Asserting on it also proves the control is labelled. */
+const paginationNav = () => screen.getByRole("navigation", { name: /pagination/i });
+
+const pageIndicator = () => within(paginationNav()).getByText(/^Page \d+ of \d+$/);
+
+/** The four navigation buttons, in the order the shared control renders them. They are
+ *  icon-only with no accessible name, so position is the only handle; the length
+ *  assertion makes a change in the shared control fail loudly here. */
+const navButtons = () => {
+  const buttons = within(paginationNav()).getAllByRole("button") as HTMLButtonElement[];
+  expect(buttons).toHaveLength(4);
+  const [first, previous, next, last] = buttons;
+  return { first, previous, next, last };
+};
+
+describe("ProjectRepoTable pagination", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders only the first five of eight repositories", () => {
+    renderTable(manyRepos(8));
+    expect(visibleRepos()).toEqual(repoNames(5));
+    expect(pageIndicator().textContent).toBe("Page 1 of 2");
+  });
+
+  it("moves to the next page", async () => {
+    const user = userEvent.setup();
+    renderTable(manyRepos(12));
+    await user.click(navButtons().next);
+    expect(visibleRepos()).toEqual(repoNames(5, 6));
+    expect(pageIndicator().textContent).toBe("Page 2 of 3");
+  });
+
+  it("jumps to the last page, back one, and home again", async () => {
+    const user = userEvent.setup();
+    renderTable(manyRepos(12));
+
+    await user.click(navButtons().last);
+    expect(visibleRepos()).toEqual(repoNames(2, 11));
+    expect(pageIndicator().textContent).toBe("Page 3 of 3");
+
+    await user.click(navButtons().previous);
+    expect(visibleRepos()).toEqual(repoNames(5, 6));
+
+    await user.click(navButtons().first);
+    expect(visibleRepos()).toEqual(repoNames(5));
+    expect(pageIndicator().textContent).toBe("Page 1 of 3");
+  });
+
+  it("cannot go back from the first page", () => {
+    renderTable(manyRepos(12));
+    const { first, previous } = navButtons();
+    expect(first.disabled).toBe(true);
+    expect(previous.disabled).toBe(true);
+  });
+
+  it("keeps exactly five repositories on a single page", () => {
+    renderTable(manyRepos(5));
+    expect(visibleRepos()).toEqual(repoNames(5));
+    expect(pageIndicator().textContent).toBe("Page 1 of 1");
+    const { next, last } = navButtons();
+    expect(next.disabled).toBe(true);
+    expect(last.disabled).toBe(true);
+  });
+
+  it("still shows a single-page control for fewer than five repositories", () => {
+    // A `data.length >= 5` gate would hide the control here and pass every other case.
+    renderTable(manyRepos(3));
+    expect(visibleRepos()).toEqual(repoNames(3));
+    expect(pageIndicator().textContent).toBe("Page 1 of 1");
+    const { next, last } = navButtons();
+    expect(next.disabled).toBe(true);
+    expect(last.disabled).toBe(true);
+  });
+
+  it("renders no pagination control at all when there are no repositories", () => {
+    renderTable([]);
+    expect(screen.getByText("No repositories found for this project.")).toBeTruthy();
+    expect(screen.queryByRole("navigation", { name: /pagination/i })).toBeNull();
+  });
+
+  it("clamps to the last page that still exists when the data shrinks", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<RepoTableHarness data={manyRepos(12)} />);
+    await user.click(navButtons().last);
+    expect(pageIndicator().textContent).toBe("Page 3 of 3");
+
+    rerender(<RepoTableHarness data={manyRepos(6)} />);
+
+    // TanStack queues its auto-reset in a microtask; flush it (and the render it
+    // would cause) so this assertion can actually see a page that moved.
+    await act(async () => {});
+
+    // Neither "Page 1 of 2" (an auto-reset to the start) nor "Page 3 of 2" (no clamp,
+    // blank body).
+    expect(pageIndicator().textContent).toBe("Page 2 of 2");
+    expect(visibleRepos()).toEqual(repoNames(1, 6));
+  });
+
+  it("keeps the current page when a refetch replaces the data", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<RepoTableHarness data={manyRepos(12)} />);
+    await user.click(navButtons().next);
+    expect(pageIndicator().textContent).toBe("Page 2 of 3");
+
+    // A background refetch hands down an equal but brand-new array. Nothing the reader
+    // is looking at has changed, so the page must not move under them.
+    rerender(<RepoTableHarness data={manyRepos(12)} />);
+
+    // TanStack queues its auto-reset in a microtask; flush it (and the render it
+    // would cause) so this assertion can actually see a page that moved.
+    await act(async () => {});
+
+    expect(pageIndicator().textContent).toBe("Page 2 of 3");
+    expect(visibleRepos()).toEqual(repoNames(5, 6));
+  });
+
+  it("offers no rows-per-page selector", () => {
+    renderTable(manyRepos(12));
+    expect(screen.queryByText("Rows per page")).toBeNull();
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  it("fires a row action for the row shown on page two", async () => {
+    const user = userEvent.setup();
+    renderTable(manyRepos(12));
+    await user.click(navButtons().next);
+    // First visible row on page 2 is the sixth repository - an action wired to the raw
+    // data array instead of the row model would open the first one.
+    await user.click(screen.getAllByRole("button", { name: "Set" })[0]);
+    expect(screen.getByTestId("domain-dialog").textContent).toContain("repo-6");
+  });
+
+  it("survives the remount its parent causes on a background refetch", async () => {
+    // repo-list.tsx swaps the whole table for a skeleton whenever the repositories are
+    // refetching, so page state held inside the table would be lost. This stands in for
+    // that parent: unmount the table, bring it back, and the page must hold.
+    const user = userEvent.setup();
+    const Parent = ({ hidden, data }: { hidden: boolean; data: IEnvRepository[] }) => {
+      const [page, setPage] = useState(0);
+      if (hidden) return <div data-testid="skeleton" />;
+      return (
+        <ProjectRepoTable
+          data={data}
+          domains={[]}
+          projectKey="pk"
+          projectEnv="dev"
+          page={page}
+          onPageChange={setPage}
+        />
+      );
+    };
+
+    const data = manyRepos(12);
+    const { rerender } = render(<Parent hidden={false} data={data} />);
+    await user.click(navButtons().next);
+    expect(pageIndicator().textContent).toBe("Page 2 of 3");
+
+    rerender(<Parent hidden data={data} />);
+    expect(screen.getByTestId("skeleton")).toBeTruthy();
+    rerender(<Parent hidden={false} data={data} />);
+
+    expect(pageIndicator().textContent).toBe("Page 2 of 3");
+    expect(visibleRepos()).toEqual(repoNames(5, 6));
   });
 });

--- a/client/app/pages/dashboard/components/project/repo-table.tsx
+++ b/client/app/pages/dashboard/components/project/repo-table.tsx
@@ -6,10 +6,13 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
+  getPaginationRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import { Pencil } from "lucide-react";
-import { useState } from "react";
+import { useLayoutEffect, useState } from "react";
+import { Pagination } from "@/components/ui-kits/pagination/pagination";
+import { DASHBOARD_TABLE_PAGE_SIZE } from "../dashboard.constant";
 import {
   Tooltip,
   TooltipContent,
@@ -99,6 +102,10 @@ interface ProjectRepoTableProps {
   domains: IDomain[];
   projectKey: string;
   projectEnv: string;
+  /** Page index is owned by the parent: this table is unmounted and remounted on every
+   *  background refetch (see repo-list.tsx), which would destroy state held here. */
+  page: number;
+  onPageChange: (pageIndex: number) => void;
 }
 
 export const ProjectRepoTable = ({
@@ -106,6 +113,8 @@ export const ProjectRepoTable = ({
   domains,
   projectKey,
   projectEnv,
+  page,
+  onPageChange,
 }: ProjectRepoTableProps) => {
   // ── Set custom domain dialog ────────────────────────────────────────────────
   const [setTarget, setSetTarget] = useState<IEnvRepository | null>(null);
@@ -122,7 +131,28 @@ export const ProjectRepoTable = ({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    // See `autoResetPageIndex` in domain-table.tsx: the queued reset would override the
+    // clamp below.
+    autoResetPageIndex: false,
+    state: { pagination: { pageIndex: page, pageSize: DASHBOARD_TABLE_PAGE_SIZE } },
+    onPaginationChange: (updater) => {
+      const next =
+        typeof updater === "function"
+          ? updater({ pageIndex: page, pageSize: DASHBOARD_TABLE_PAGE_SIZE })
+          : updater;
+      onPageChange(next.pageIndex);
+    },
   });
+
+  const lastPageIndex = Math.max(0, table.getPageCount() - 1);
+
+  // Clamp a now-out-of-range page back to the last one that exists, before paint.
+  // Routed through the table (not straight to onPageChange) so every page change
+  // takes the same path out through onPaginationChange.
+  useLayoutEffect(() => {
+    if (page > lastPageIndex) table.setPageIndex(lastPageIndex);
+  }, [page, lastPageIndex, table]);
 
   return (
     <>
@@ -183,6 +213,21 @@ export const ProjectRepoTable = ({
           </tbody>
         </table>
       </div>
+
+      {/* Pagination — same component and same rules as the Domains section. */}
+      {data.length > 0 && (
+        <nav
+          aria-label="Repositories pagination"
+          className="mt-4 flex items-center md:justify-end"
+        >
+          <Pagination
+            page={page}
+            pageSize={DASHBOARD_TABLE_PAGE_SIZE}
+            totalCount={data.length}
+            onChange={(nextPageIndex) => table.setPageIndex(nextPageIndex)}
+          />
+        </nav>
+      )}
     </>
   );
 };

--- a/client/app/pages/dashboard/dashboard-overview.test.tsx
+++ b/client/app/pages/dashboard/dashboard-overview.test.tsx
@@ -1,0 +1,244 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import type { IDomain, IEnvRepository } from "@seliseblocks/genesis-os/models";
+
+// `useGetProject` stays disabled until the impersonation store reports a resolved
+// tenant, so that store is stubbed. The package barrels are stubbed the way the rest of
+// the suite stubs them: their dist bundle reads `import.meta.env` at module scope, which
+// is undefined for an externalised dependency under vitest.
+const h = vi.hoisted(() => ({ tenant: "tenant-1" }));
+
+vi.mock("@seliseblocks/genesis-os", () => {
+  // The app's own ui-kits/tooltip re-exports these straight from the package barrel, so
+  // stubbing the barrel means stubbing them too.
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+  return {
+    useImpersonateStore: () => ({
+      isInitialized: true,
+      isImpersonated: false,
+      impersonatedTenantId: "",
+      originalTenantId: h.tenant,
+    }),
+    useProjectStore: () => ({ setProjects: vi.fn() }),
+    Tooltip: Passthrough,
+    TooltipTrigger: Passthrough,
+    TooltipContent: Passthrough,
+    TooltipProvider: Passthrough,
+  };
+});
+
+vi.mock("@seliseblocks/genesis-os/components", () => ({
+  DashboardSectionCard: ({
+    title,
+    children,
+  }: {
+    title: string;
+    children: React.ReactNode;
+  }) => (
+    <section>
+      <h2>{title}</h2>
+      {children}
+    </section>
+  ),
+  Button: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  CopyToClipboardButton: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  RenderConditionally: ({
+    condition,
+    children,
+  }: {
+    condition: boolean;
+    children: React.ReactNode;
+  }) => (condition ? <>{children}</> : null),
+}));
+
+vi.mock("@seliseblocks/genesis-os/utils", () => ({
+  formatFullDate: () => "FMT-DATE",
+  showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
+}));
+
+// Dialogs and the sibling header sections are not what this test is about; the tables,
+// their hooks and the query client stay real.
+vi.mock("./components/domain/domain-form-dialog", () => ({
+  DomainFormDialog: () => null,
+}));
+vi.mock("./components/cname/dialog", () => ({ CnameValidatorDialog: () => null }));
+vi.mock("./components/custom-domain/dialog", () => ({ SetCustomDomainDialog: () => null }));
+vi.mock("./components/project/overview", () => ({ ProjectOverview: () => null }));
+vi.mock("./components/project/actions", () => ({ ProjectActions: () => null }));
+
+import { createWrapper } from "@/test-utils/test-providers/query-client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { projectService } from "@/services/project.service";
+import { projectService as crossProjectService } from "@blocks-identifier/services/project.service";
+import { DashboardOverview } from "./dashboard-overview";
+
+const applications = Array.from({ length: 12 }, (_item, index) => ({
+  domain: `domain-${index + 1}.com`,
+  isDomainVerified: false,
+  cookieDomain: `.domain-${index + 1}.com`,
+})) as unknown as IDomain[];
+
+const repositories = Array.from({ length: 12 }, (_item, index) => ({
+  repoName: `repo-${index + 1}`,
+  defaultDeploymentUrl: `repo-${index + 1}.default.dev`,
+  customDeploymentUrl: "",
+  lastDeploymentDate: "2024-06-01T10:00:00",
+})) as unknown as IEnvRepository[];
+
+const project = {
+  itemId: "project-1",
+  name: "Blocks",
+  environment: "dev",
+  tenantId: "tenant-1",
+  createdBy: "someone",
+  isDisabled: false,
+  applications,
+};
+
+/** Next is the third of the four navigation buttons the shared control renders. */
+const nextButtonWithin = (indicator: HTMLElement) => {
+  const buttons = Array.from(
+    indicator.parentElement?.querySelectorAll("button") ?? [],
+  ) as HTMLButtonElement[];
+  expect(buttons).toHaveLength(4);
+  return buttons[2];
+};
+
+describe("DashboardOverview pagination (#471)", () => {
+  beforeEach(() => {
+    h.tenant = "tenant-1";
+  });
+
+  it("pages both sections without issuing another request for either list", async () => {
+    // Spying on the service singletons rather than on the hooks: a hook-call count is
+    // not a request count, and mocking the hooks would make this assertion vacuous.
+    const getProject = vi
+      .spyOn(projectService, "getProject")
+      .mockResolvedValue({ data: project } as never);
+    const getEnvRepositories = vi
+      .spyOn(crossProjectService, "getEnvRepositories")
+      .mockResolvedValue({ data: repositories, errors: null, isSuccess: true });
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <DashboardOverview />
+      </MemoryRouter>,
+      { wrapper: createWrapper() },
+    );
+
+    // Both sections have loaded, each showing its first page only.
+    expect(await screen.findByText("domain-1.com")).toBeTruthy();
+    expect(await screen.findByText("repo-1")).toBeTruthy();
+    expect(screen.queryByText("domain-6.com")).toBeNull();
+    expect(screen.queryByText("repo-6")).toBeNull();
+
+    expect(getProject).toHaveBeenCalledTimes(1);
+    expect(getEnvRepositories).toHaveBeenCalledTimes(1);
+
+    const indicators = screen.getAllByText(/^Page \d+ of \d+$/);
+    expect(indicators).toHaveLength(2);
+
+    for (const indicator of indicators) {
+      await user.click(nextButtonWithin(indicator));
+    }
+
+    expect(await screen.findByText("domain-6.com")).toBeTruthy();
+    expect(await screen.findByText("repo-6")).toBeTruthy();
+
+    // The whole point of doing this client side: paging is not a round trip.
+    expect(getProject).toHaveBeenCalledTimes(1);
+    expect(getEnvRepositories).toHaveBeenCalledTimes(1);
+
+    getProject.mockRestore();
+    getEnvRepositories.mockRestore();
+  });
+
+  it("does not carry a page index across a project switch", async () => {
+    // Both sections hold a page index now. Switching projects reuses the same component
+    // positions, so without a key the reader lands on page 2 of a project they just left.
+    const projectB = {
+      ...project,
+      tenantId: "tenant-2",
+      name: "Other",
+      applications: Array.from({ length: 12 }, (_item, index) => ({
+        domain: `other-${index + 1}.com`,
+        isDomainVerified: false,
+        cookieDomain: `.other-${index + 1}.com`,
+      })),
+    };
+
+    vi.spyOn(projectService, "getProject").mockImplementation(
+      async () => ({ data: h.tenant === "tenant-1" ? project : projectB }) as never,
+    );
+    vi.spyOn(crossProjectService, "getEnvRepositories").mockResolvedValue({
+      data: repositories,
+      errors: null,
+      isSuccess: true,
+    });
+
+    // Seed the second project into the cache. That is the case that actually risks a
+    // leak: data resolves synchronously on the switch, so DashboardOverview never returns
+    // null and React reuses the mounted sections instead of remounting them. Without a
+    // seeded cache this test passes even with the keys removed - the null gap resets the
+    // page for unrelated reasons and proves nothing.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(["identifier", "project", "tenant-2"], { data: projectB });
+    queryClient.setQueryData(["env-repositories", "tenant-2"], {
+      data: repositories,
+      errors: null,
+      isSuccess: true,
+    });
+
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DashboardOverview />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("domain-1.com")).toBeTruthy();
+    expect(await screen.findByText("repo-1")).toBeTruthy();
+
+    // BOTH sections are advanced: paging only Domains would let the repositories key
+    // be removed without failing anything.
+    const nextIn = (name: RegExp) => {
+      const nav = screen.getAllByRole("navigation", { name })[0];
+      return (within(nav).getAllByRole("button") as HTMLButtonElement[])[2];
+    };
+    await user.click(nextIn(/domains pagination/i));
+    await user.click(nextIn(/repositories pagination/i));
+    expect(await screen.findByText("domain-6.com")).toBeTruthy();
+    expect(await screen.findByText("repo-6")).toBeTruthy();
+
+    h.tenant = "tenant-2";
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DashboardOverview />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Both sections start the new project on their own first page, not on page 2.
+    expect(await screen.findByText("other-1.com")).toBeTruthy();
+    expect(screen.queryByText("other-6.com")).toBeNull();
+    expect(await screen.findByText("repo-1")).toBeTruthy();
+    expect(screen.queryByText("repo-6")).toBeNull();
+
+    const indicatorIn = (name: RegExp) =>
+      within(screen.getAllByRole("navigation", { name })[0]).getByText(/^Page \d+ of \d+$/)
+        .textContent;
+    expect(indicatorIn(/domains pagination/i)).toBe("Page 1 of 3");
+    expect(indicatorIn(/repositories pagination/i)).toBe("Page 1 of 3");
+  });
+});

--- a/client/app/pages/dashboard/dashboard-overview.tsx
+++ b/client/app/pages/dashboard/dashboard-overview.tsx
@@ -23,8 +23,17 @@ export const DashboardOverview = () => {
           isFetching={isFetching}
         />
       </div>
-      <DomainsSection applications={data?.data.applications || []} />
-      <ProjectRepoList project={data?.data} isLoading={isFetching} />
+      {/* Keyed on the project: both sections now hold a page index, and switching
+          projects must not land the reader on page 2 of a project they just left. */}
+      <DomainsSection
+        key={`domains-${data.data.tenantId}`}
+        applications={data?.data.applications || []}
+      />
+      <ProjectRepoList
+        key={`repos-${data.data.tenantId}`}
+        project={data?.data}
+        isLoading={isFetching}
+      />
     </main>
   );
 };


### PR DESCRIPTION
Closes #471.

Both Dashboard sections now show at most five rows per page behind a visible control. Frontend only — no new request, no change to any request shape, no backend touched.

## What changed

- **Reuses the existing `ui-kits/pagination` control** rather than adding one. Its `pageSizeOptions` prop is optional and the selector only renders when it is supplied, so omitting it gives C4's "no rows-per-page selector" for free. `TablePagination` was left alone, as A1 asks.
- **The control is omitted entirely when a section has no rows**, so an empty state is never captioned "Page 1 of 1".
- **The reader's page survives a background refetch**, and an out-of-range page clamps to the last page that still exists — deleting the last row of the last page lands there rather than on a blank table or back at the start.
- **The Repositories page index lives in `ProjectRepoList`** (see the deviation below).
- **Both sections are keyed on the project**, so switching to a cached project does not carry a page index into it.

## One deviation from the ticket, declared

The must-not-break list says `repo-list.tsx` is unaffected. It is changed, and it has to be.

`repo-list.tsx` swaps the whole table for a skeleton whenever `isFetchingEnvRepos` is true, which is on **every** background refetch — not just the first load. A page index held inside `ProjectRepoTable` is therefore destroyed on every refetch, and the reader is silently returned to page 1 mid-browse. So the page index moved up into `ProjectRepoList`, which stays mounted. The array passed down is unchanged and the slicing still happens inside the table, so the spirit of that note holds.

The alternative — dropping `isFetchingEnvRepos` from the skeleton gate — would change existing loading behaviour, which the same list forbids more clearly. The Domains section has no equivalent gate, which is why only Repositories needed this.

## Two defects in the ticket

- **§9 requires "the §7 E2E instructions have been executed", but there is no §7.** The body runs §6 → ASSUMPTIONS/DECISIONS → §9. There are no E2E instructions to execute, so that line of the definition of done cannot be satisfied as written. Flagging rather than silently ticking it.
- §9 asks for "new tests in `domain-table.test.tsx` and `repo-table.test.tsx`"; both files already existed and were extended.

## Verification

48 tests across four files, 24 of them new. Line coverage on changed files: `dashboard-overview.tsx` 100%, `repo-list.tsx` 100%, `repo-table.tsx` 94.4%, `domain-table.tsx` 93.1% — every uncovered line is a pre-existing dialog callback.

Each acceptance criterion was checked by breaking the implementation and confirming a test fails: page size changed; the pagination row model removed; the control rendered unconditionally; each table's clamp removed; `autoResetPageIndex` switched back on; the page index moved back inside the repo table (fails only the remount test); `repo-list` no longer feeding the index; `onPaginationChange` dropping it; a selector added; a row action hard-wired to the first row of the array; next/last left enabled on a single page; each project key removed; and `isFetchingEnvRepos` dropped from the skeleton gate. Two probes found tests that passed for the wrong reason and both were fixed before this PR.

Lint and `tsc -b` are clean on every changed file.

**Pre-existing on `dev`, not from this change:** the client suite has both genuine failures and flaky ones (27 failing in one full run, 15 in another, from a set that shifts between runs); none are in the files this PR touches. Separately, `npm run type-check` is a no-op here — the root `tsconfig.json` has `files: []` with project references, so `tsc --noEmit` compiles nothing and always exits 0. The real check is `tsc -b`, which `npm run build` runs.

## Follow-up worth filing

The four navigation buttons inside the shared `ui-kits/pagination` component are icon-only with no `aria-label`, so they have no accessible name — a screen reader announces four indistinguishable "button" controls. That is pre-existing and affects roughly fifteen other call sites, and this ticket explicitly warns against changing shared pagination components, so I did not edit it here. Each new control is wrapped in a named `nav` landmark instead, which is as far as this ticket's blast radius should reach.
