### PR TITLE
chore: update dependencies and improve project policy filter

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -32,8 +32,8 @@
         "@radix-ui/react-tabs": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.2",
-        "@seliseblocks/genesis-os": "4.3.0",
-        "@seliseblocks/mailcraft": "0.2.8",
+        "@seliseblocks/genesis-os": "4.3.1",
+        "@seliseblocks/mailcraft": "0.2.9",
         "@tanstack/react-query": "^5.62.11",
         "@tanstack/react-query-devtools": "^5.62.11",
         "@tanstack/react-table": "^8.20.5",
@@ -3480,9 +3480,9 @@
       "license": "MIT"
     },
     "node_modules/@seliseblocks/genesis-os": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@seliseblocks/genesis-os/-/genesis-os-4.3.0.tgz",
-      "integrity": "sha512-Nd7HDVxLbUTyjkWGDtAMMIl+6azEO1Fw7kAQJ6fIITvy+mQKATz/5UdyGjL0hlc31bCxOzGZn3ViMDFDlf/XGw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@seliseblocks/genesis-os/-/genesis-os-4.3.1.tgz",
+      "integrity": "sha512-yhU843FUJcTj7iHO+Nven46Oe04nf4QATrkpezDCvtlP3OW/uHw8MVoZnfcCfjZR0DU64f+TAW013MNz7MltZQ==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/client/package.json
+++ b/client/package.json
@@ -45,7 +45,7 @@
     "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.2",
-    "@seliseblocks/genesis-os": "4.3.0",
+    "@seliseblocks/genesis-os": "4.3.1",
     "@seliseblocks/mailcraft": "0.2.9",
     "@tanstack/react-query": "^5.62.11",
     "@tanstack/react-query-devtools": "^5.62.11",

--- a/server/Identifier.DomainService/Access/ProjectPolicyFilter.cs
+++ b/server/Identifier.DomainService/Access/ProjectPolicyFilter.cs
@@ -108,47 +108,79 @@ namespace DomainService.Access
         /// </summary>
         private async Task<string?> ResolveGroupAsync(ActionExecutingContext context)
         {
+            var namesAProject = false;
+
             foreach (var name in GroupNames)
             {
-                if (Find(context, name) is { Length: > 0 } groupId) return groupId;
+                if (!TryFind(context, name, out var groupId)) continue;
+
+                namesAProject = true;
+                if (!string.IsNullOrWhiteSpace(groupId)) return groupId;
             }
 
             foreach (var name in ProjectNames)
             {
-                if (Find(context, name) is { Length: > 0 } projectRef)
-                {
-                    var groupId = await _access.ResolveGroupOfProjectAsync(projectRef);
-                    if (!string.IsNullOrWhiteSpace(groupId)) return groupId;
-                }
+                if (!TryFind(context, name, out var projectRef)) continue;
+
+                namesAProject = true;
+                if (string.IsNullOrWhiteSpace(projectRef)) continue;
+
+                var groupId = await _access.ResolveGroupOfProjectAsync(projectRef);
+                if (!string.IsNullOrWhiteSpace(groupId)) return groupId;
             }
 
-            // Endpoints naming no project, acting on whichever one the caller is currently in —
-            // Project/Disable, whose request object is empty.
+            // A request that carries a project field but left it blank is deliberately unscoped,
+            // and is not the same thing as a request with no field to fill in. Project/Create
+            // with no TenantGroupId is a brand-new project, which belongs to nobody yet; falling
+            // through to the caller's ambient tenant authorized it against whichever project
+            // they had open, and refused them the creation of their own project.
+            if (namesAProject) return null;
+
+            // Endpoints naming no project at all, acting on whichever one the caller is currently
+            // in — Project/Disable, whose request object is empty.
             return await _access.ResolveGroupOfProjectAsync(BlocksContext.GetContext()?.TenantId ?? string.Empty);
         }
 
-        private static string? Find(ActionExecutingContext context, string wanted)
+        /// <summary>
+        /// Looks for <paramref name="wanted"/> on the bound request. Returns whether the request
+        /// carries it at all, which is separate from whether it was filled in — see
+        /// <see cref="ResolveGroupAsync"/>, where the difference decides between "no project" and
+        /// "the project the caller is in".
+        /// </summary>
+        private static bool TryFind(ActionExecutingContext context, string wanted, out string? value)
         {
+            value = null;
+            var found = false;
+
             foreach (var (argumentName, argument) in context.ActionArguments)
             {
-                if (argument is null) continue;
-
-                if (argument is string text)
+                // A bare [FromQuery] string binds to null when it is absent from the query
+                // string, so the argument's presence — not its value — is what declares it.
+                if (argumentName.Equals(wanted, StringComparison.OrdinalIgnoreCase)
+                    && argument is string or null)
                 {
-                    if (argumentName.Equals(wanted, StringComparison.OrdinalIgnoreCase)) return text;
+                    found = true;
+                    value = argument as string;
+                    if (!string.IsNullOrWhiteSpace(value)) return true;
                     continue;
                 }
+
+                if (argument is null or string) continue;
 
                 var property = argument.GetType().GetProperty(wanted,
                     BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
 
-                if (property?.GetValue(argument) is string value && !string.IsNullOrWhiteSpace(value))
+                if (property is null || property.PropertyType != typeof(string)) continue;
+
+                found = true;
+                if (property.GetValue(argument) is string text && !string.IsNullOrWhiteSpace(text))
                 {
-                    return value;
+                    value = text;
+                    return true;
                 }
             }
 
-            return null;
+            return found;
         }
 
         /// <summary>

--- a/server/Identifier.DomainService/Access/Services/ProjectAccessService.cs
+++ b/server/Identifier.DomainService/Access/Services/ProjectAccessService.cs
@@ -46,6 +46,7 @@ namespace DomainService.Access.Services
                 : await _peopleRepository.GetProjectPeoplesAsync(userId, tenantIds);
 
             var catalog = await GetCatalogAsync(cancellationToken).ConfigureAwait(false);
+            var isOwner = rows.Exists(row => row.IsCreator);
 
             var context = new ProjectAccessContext
             {
@@ -66,8 +67,16 @@ namespace DomainService.Access.Services
                 // are shut. TransferOwnership is [ProjectPolicy(OwnerOnly)], and provisioning an
                 // environment attributes the row to the group's existing owner instead of to
                 // whoever triggered it.
-                IsOwner = rows.Exists(row => row.IsCreator),
-                Policies = Intersect(Union(rows), catalog),
+                IsOwner = isOwner,
+                // The owner holds the whole catalog, not the (usually empty) grants on their own
+                // rows. Grants exist to give a contributor a subset of what the owner can do, so
+                // there is never anything to write onto an owner's row — SaveAccessPolicy
+                // refuses to — and reading their Policies literally answers "the owner may do
+                // nothing". The filter short-circuits on IsOwner before it looks here, so this
+                // is what keeps every *other* reader of a resolved context agreeing with it.
+                Policies = isOwner
+                    ? ProjectAccessCatalog.Flatten(catalog).ToHashSet(StringComparer.Ordinal)
+                    : Intersect(Union(rows), catalog),
             };
 
             items?[cacheKey] = context;
@@ -152,16 +161,13 @@ namespace DomainService.Access.Services
             var context = await ResolveAsync(projectGroupId, cancellationToken).ConfigureAwait(false);
             var catalog = await GetCatalogAsync(cancellationToken).ConfigureAwait(false);
 
-            var policies = context.IsOwner
-                ? ProjectAccessCatalog.Flatten(catalog).ToHashSet(StringComparer.Ordinal)
-                : context.Policies;
-
             return new GetMyAccessResponse
             {
                 IsSuccess = true,
                 IsOwner = context.IsOwner,
                 Role = context.IsOwner ? ProjectRoles.Owner : ProjectRoles.Contributor,
-                Menus = ToMenuGrants(policies, catalog),
+                // Owners already carry the whole catalog out of ResolveAsync.
+                Menus = ToMenuGrants(context.Policies, catalog),
                 Environments = context.TenantIds.Count == 0 ? [] : await MemberEnvironmentsAsync(context),
             };
         }

--- a/server/Identifier.DomainService/ManagedService/Services/ServiceManagementRepository.cs
+++ b/server/Identifier.DomainService/ManagedService/Services/ServiceManagementRepository.cs
@@ -23,7 +23,7 @@ namespace DomainService.ManagedService.Services
         var blocksContext = BlocksContext.GetContext();
         if (blocksContext.Impersonated)
         {
-         return _dbContextProvider.GetDatabase(_blocksSecret.DatabaseConnectionString, "BlocksRootDb");
+         return _dbContextProvider.GetDatabase(_blocksSecret.DatabaseConnectionString, IdentifierConstants.RootDatabaseName);
         }
         return _dbContextProvider.GetDatabase(blocksContext.TenantId);
        }

--- a/server/Identifier.DomainService/People/Services/PeopleRepository.cs
+++ b/server/Identifier.DomainService/People/Services/PeopleRepository.cs
@@ -14,9 +14,32 @@ namespace DomainService.People
         private readonly IDbContextProvider _dbContextProvider;
         private readonly ITenants _tenants;
         private readonly IProjectRepository _projectRepository;
+        private readonly IMongoDatabase _rootDb;
 
         private const string _userCollectionName = "Users";
         private const string _peopleCollectionName = "ProjectPeoples";
+
+        /// <summary>
+        /// ProjectPeoples lives in the root database and nowhere else: every write to it — the
+        /// creator row provisioning stamps, the invite inserts, the disable cleanup — goes
+        /// through <see cref="IProjectRepository"/>, which pins the collection to BlocksRootDb.
+        /// </summary>
+        /// <remarks>
+        /// Read through the plain <see cref="IDbContextProvider.GetCollection{T}(string)"/>
+        /// instead and the handle resolves to <c>BlocksContext.TenantId</c>'s own database. Once
+        /// the console has impersonated a project — which Project/Disable relies on, since it
+        /// takes the impersonated tenant as the project to disable — that is the project's own
+        /// tenant database, where these rows have never been written. Every read came back
+        /// empty, and because <c>ProjectAccessService</c> decides ownership from exactly these
+        /// rows, the owner of a project was refused as a non-member of it: "Only the project
+        /// owner can do this", with <c>rows=0; ownerRows=0</c>.
+        ///
+        /// The writes were wrong in the same direction and less visibly: an invite, an access
+        /// grant or a remove-access issued from inside a project landed in (or matched nothing
+        /// in) the project's tenant database, leaving rows split across two databases.
+        /// </remarks>
+        private IMongoCollection<ProjectPeople> PeopleCollection =>
+            _rootDb.GetCollection<ProjectPeople>(_peopleCollectionName);
 
         // Shortest search term that will actually query; below this the filter is ignored (all people returned).
         private const int MinSearchTermLength = 3;
@@ -35,16 +58,20 @@ namespace DomainService.People
             { "_id", 1 }
         });
 
-        public PeopleRepository(IDbContextProvider dbContextProvider, ITenants tenants, IProjectRepository projectRepository)
+        public PeopleRepository(IDbContextProvider dbContextProvider,
+                               ITenants tenants,
+                               IProjectRepository projectRepository,
+                               IBlocksSecret blocksSecret)
         {
             _dbContextProvider = dbContextProvider;
             _tenants = tenants;
             _projectRepository = projectRepository;
+            _rootDb = dbContextProvider.GetDatabase(blocksSecret.DatabaseConnectionString, IdentifierConstants.RootDatabaseName);
         }
 
         public async Task<(List<GetProjectPeople> peoples, long totalCount, long peoplesTotalCount, bool isOwner)> GetPeoplesAsync(GetPeoplesRequest request)
         {
-            var peopleCollection = _dbContextProvider.GetCollection<ProjectPeople>(_peopleCollectionName);
+            var peopleCollection = PeopleCollection;
             var userCollection = _dbContextProvider.GetCollection<User>(_userCollectionName);
 
             var projectIds = await _projectRepository.GetProjectIdsByGroupId(request.ProjectGroupId);
@@ -193,7 +220,7 @@ namespace DomainService.People
 
         public async Task<bool> InsertPeoplesAsync(List<ProjectPeople> projectPeoples)
         {
-            await _dbContextProvider.GetCollection<ProjectPeople>(_peopleCollectionName).InsertManyAsync(projectPeoples);
+            await PeopleCollection.InsertManyAsync(projectPeoples);
             return true;
         }
 
@@ -201,7 +228,7 @@ namespace DomainService.People
         {
             var filter = Builders<ProjectPeople>.Filter.Eq(x => x.Email, email)
                 & Builders<ProjectPeople>.Filter.In(x => x.TenantId, tenantIds);
-            var result = await _dbContextProvider.GetCollection<ProjectPeople>(_peopleCollectionName).DeleteManyAsync(filter);
+            var result = await PeopleCollection.DeleteManyAsync(filter);
             return result.IsAcknowledged;
         }
 
@@ -209,20 +236,20 @@ namespace DomainService.People
         {
             var filter = Builders<ProjectPeople>.Filter.In(x => x.ItemId, ids);
             var update = Builders<ProjectPeople>.Update.Set(x => x.IsInvitationConfirmed, true);
-            var result = await _dbContextProvider.GetCollection<ProjectPeople>(_peopleCollectionName).UpdateManyAsync(filter, update);
+            var result = await PeopleCollection.UpdateManyAsync(filter, update);
             return result.IsAcknowledged;
         }
 
         public async Task<List<ProjectPeople>> GetProjectPeoplesAsync(string userId, List<string> tenantIds)
         {
             var filter = Builders<ProjectPeople>.Filter.Eq(x => x.UserId, userId) & Builders<ProjectPeople>.Filter.In(x => x.TenantId, tenantIds);
-            return await _dbContextProvider.GetCollection<ProjectPeople>(_peopleCollectionName).Find(filter).ToListAsync();
+            return await PeopleCollection.Find(filter).ToListAsync();
         }
 
         public async Task<ProjectPeople> GetProjectPeopleAsync(string id)
         {
             var filter = Builders<ProjectPeople>.Filter.Eq(x => x.ItemId, id);
-            return await _dbContextProvider.GetCollection<ProjectPeople>(_peopleCollectionName).Find(filter).FirstOrDefaultAsync();
+            return await PeopleCollection.Find(filter).FirstOrDefaultAsync();
         }
 
         /// <summary>
@@ -237,7 +264,7 @@ namespace DomainService.People
                        & Builders<ProjectPeople>.Filter.In(x => x.TenantId, tenantIds)
                        & Builders<ProjectPeople>.Filter.Eq(x => x.IsCreator, true);
 
-            return await _dbContextProvider.GetCollection<ProjectPeople>(_peopleCollectionName)
+            return await PeopleCollection
                 .CountDocumentsAsync(filter) > 0;
         }
 
@@ -251,7 +278,7 @@ namespace DomainService.People
                 .Set(x => x.LastUpdatedDate, DateTime.UtcNow)
                 .Set(x => x.LastUpdatedBy, BlocksContext.GetContext()?.UserId);
 
-            var result = await _dbContextProvider.GetCollection<ProjectPeople>(_peopleCollectionName)
+            var result = await PeopleCollection
                 .UpdateManyAsync(filter, update);
 
             return result.MatchedCount > 0;
@@ -263,14 +290,14 @@ namespace DomainService.People
             var update = Builders<ProjectPeople>.Update.Set(x => x.IsCreator, ownerShipStatus)
                                                        .Set(x => x.IsInvitationConfirmed, true)
                                                        .Set(x => x.IsInvitationSent, true);
-            var result = await _dbContextProvider.GetCollection<ProjectPeople>(_peopleCollectionName).UpdateManyAsync(filter, update);
+            var result = await PeopleCollection.UpdateManyAsync(filter, update);
             return result.IsAcknowledged;
         }
 
         public async Task<ProjectPeople> GetProjectPeopleByTenantIdAndUserIdAsync(string tenantId, string userId)
         {
             var filter = Builders<ProjectPeople>.Filter.Eq(x => x.TenantId, tenantId) & Builders<ProjectPeople>.Filter.Eq(x => x.UserId, userId);
-            return await _dbContextProvider.GetCollection<ProjectPeople>(_peopleCollectionName).Find(filter).FirstOrDefaultAsync();
+            return await PeopleCollection.Find(filter).FirstOrDefaultAsync();
         }
 
         public async Task<User> GetUserByEmailAsync(string email)

--- a/server/Identifier.DomainService/Project/Services/ProjectManagementService.cs
+++ b/server/Identifier.DomainService/Project/Services/ProjectManagementService.cs
@@ -108,6 +108,16 @@ namespace DomainService.Projects
         {
             if (statusTracer.InsertedIntoProjectPeople) return;
 
+            // Idempotent per environment, which the tracer flag alone does not make it: a
+            // brand-new group's environments are claimed by the API before they are queued, and
+            // a resumed run can arrive here with the row already written and the flag not yet
+            // saved. Both used to leave the same person holding two creator rows on one tenant.
+            if (await _projectRepository.GetOwnerUserIdAsync(project.TenantId) is not null)
+            {
+                statusTracer.InsertedIntoProjectPeople = true;
+                return;
+            }
+
             // Ownership of a new environment belongs to the group's existing owner, never to
             // whoever created it. Ownership is "IsCreator on every tenant in the group", so
             // stamping the caller here would hand the whole group to anyone who could add an
@@ -115,25 +125,36 @@ namespace DomainService.Projects
             // a no-op — and a permanent guard if that ever changes.
             var groupOwner = await _projectRepository.GetGroupOwnerAsync(project.TenantGroupId);
 
-            await _projectRepository.InsertPeopleAsync(new ProjectPeople
+            await InsertCreatorRowAsync(project,
+                groupOwner?.UserId ?? project.CreatedBy,
+                // Taken from the owner's existing row rather than the caller's context: on the
+                // restore path those are two different people, which used to stamp the
+                // restorer's address onto the creator's row.
+                groupOwner?.Email ?? BlocksContext.GetContext()?.UserName ?? "");
+
+            statusTracer.InsertedIntoProjectPeople = true;
+
+        }
+
+        /// <summary>
+        /// Records who owns one environment. <c>ProjectPeople.IsCreator</c> is the only place
+        /// ownership is ever written — see docs/specs/transfer-ownership-createdby-decoupling.md
+        /// — so both the API and the provisioning worker go through here rather than each
+        /// composing the row themselves.
+        /// </summary>
+        private Task InsertCreatorRowAsync(Tenant project, string? userId, string email) =>
+            _projectRepository.InsertPeopleAsync(new ProjectPeople
             {
                 ItemId = Guid.NewGuid().ToString(),
-                UserId = groupOwner?.UserId ?? project.CreatedBy,
+                UserId = userId,
                 TenantId = project.TenantId,
                 IsCreator = true,
                 CreatedDate = DateTime.UtcNow,
                 LastUpdatedDate = DateTime.UtcNow,
                 IsInvitationConfirmed = true,
                 IsInvitationSent = true,
-                // Taken from the owner's existing row rather than the caller's context: on the
-                // restore path those are two different people, which used to stamp the
-                // restorer's address onto the creator's row.
-                Email = groupOwner?.Email ?? BlocksContext.GetContext()?.UserName ?? ""
+                Email = email
             });
-
-            statusTracer.InsertedIntoProjectPeople = true;
-
-        }
 
         private async Task UploadPrivateCertificateIfNeeded(ProjectStatusTracer statusTracer, X509Certificate2 privateKeyCertificate, Tenant project)
         {
@@ -273,7 +294,8 @@ namespace DomainService.Projects
 
         public async Task<CreateProjectResponse> SaveProjectAsync(CreateProjectRequest project)
         {
-            var groupId = string.IsNullOrEmpty(project.TenantGroupId) ? Guid.NewGuid().ToString("n") : project.TenantGroupId;
+            var isNewGroup = string.IsNullOrEmpty(project.TenantGroupId);
+            var groupId = isNewGroup ? Guid.NewGuid().ToString("n") : project.TenantGroupId;
             await ManageTenantAssetAsync(project, groupId);
 
             foreach (var applicationContext in project.applicationContexts)
@@ -281,6 +303,20 @@ namespace DomainService.Projects
                 var tenant = await MapAsync(project, applicationContext, groupId);
                 await Task.WhenAll(_projectRepository.SaveRepoInfoAsync(tenant, project.Resources),
                                    _projectRepository.InsertProjectAsync(tenant));
+
+                // Ownership is recorded here rather than being left to the worker. Provisioning
+                // is asynchronous, so the creator row appeared only once the worker had picked
+                // the project up; until then the group had environments and no owner, and every
+                // [ProjectPolicy(OwnerOnly)] endpoint refused the person who had just created
+                // it — adding an environment and deleting the project among them.
+                //
+                // Only for a brand-new group, where the caller is the creator by definition.
+                // Appending an environment to an existing group must leave ownership exactly
+                // where it is, which is what the worker's GetGroupOwnerAsync goes on to do.
+                if (isNewGroup)
+                {
+                    await InsertCreatorRowAsync(tenant, tenant.CreatedBy, BlocksContext.GetContext()?.UserName ?? "");
+                }
 
                 await Task.WhenAll(_messageClient.SendToConsumerAsync(new ConsumerMessage<Tenant> { ConsumerName = IdentifierConstants.IdentifierQueueName, Payload = tenant }));
             }
@@ -493,14 +529,17 @@ namespace DomainService.Projects
             var blocksContext = BlocksContext.GetContext();
             var project = await _projectRepository.GetByTenantIdAsync(blocksContext.TenantId);
 
-            if(project.IsRootTenant)
-            {
-             return new BaseResponse() { IsSuccess = false, Errors = new Dictionary<string, string> { { "root_tenant", $"Root tenant cannot be updated" } } };
-            }
-
+            // Null before root-tenant: the root-tenant guard was added above this one and
+            // dereferenced a project that may not exist, so an unknown tenant threw instead of
+            // being reported as one.
             if (project == null)
             {
                 return new BaseResponse() { IsSuccess = false, Errors = new Dictionary<string, string> { { "project_not_found", $"No project found with id {blocksContext.TenantId}" } } };
+            }
+
+            if(project.IsRootTenant)
+            {
+             return new BaseResponse() { IsSuccess = false, Errors = new Dictionary<string, string> { { "root_tenant", $"Root tenant cannot be updated" } } };
             }
 
             project.LastUpdatedDate = DateTime.UtcNow;

--- a/server/Identifier.DomainService/Project/Services/ProjectRepository.cs
+++ b/server/Identifier.DomainService/Project/Services/ProjectRepository.cs
@@ -40,7 +40,7 @@ namespace DomainService.Projects
 
             if (blocksContext?.Impersonated ?? true)
             {
-                return _dbContextProvider.GetDatabase(_blocksSecret.DatabaseConnectionString, "BlocksRootDb");
+                return _dbContextProvider.GetDatabase(_blocksSecret.DatabaseConnectionString, IdentifierConstants.RootDatabaseName);
             }
 
             return _dbContextProvider.GetDatabase(blocksContext.TenantId);

--- a/server/Identifier.DomainService/Shared/Utilities/IdentifierConstants.cs
+++ b/server/Identifier.DomainService/Shared/Utilities/IdentifierConstants.cs
@@ -19,6 +19,13 @@ namespace DomainService.Shared
         public const string MigrationTrackerCollectionName = "MigrationTrackers";
         public const string ThirdPartyJWTClaimsCollectionName = "ThirdPartyJWTClaims";
 
+        /// <summary>
+        /// The one database every cross-project collection lives in. ProjectPeoples in
+        /// particular is only ever written here, so anything deciding project membership or
+        /// ownership has to read it from here too rather than from the caller's tenant database.
+        /// </summary>
+        public const string RootDatabaseName = "BlocksRootDb";
+
         public const string IdentifierQueueName = "blocks_project_listener";
         public const string DataCleanupQueue = "blocks_data_cleanup_listener";
         public const string LanguageDataMigrationQueue = "blocks_localization_environment_data_migration_listener";

--- a/server/XUnitTest/Integration/PeopleRepositoryTests.cs
+++ b/server/XUnitTest/Integration/PeopleRepositoryTests.cs
@@ -9,6 +9,7 @@ using DomainService.Projects;
 using FluentAssertions;
 using MongoDB.Driver;
 using Moq;
+using XUnitTest.TestSupport;
 
 namespace XUnitTest.Integration
 {
@@ -25,7 +26,9 @@ namespace XUnitTest.Integration
         private readonly Mock<ITenants> _tenants = new();
         private readonly Mock<IProjectRepository> _projectRepo = new();
 
-        private PeopleRepository NewRepository()
+        private PeopleRepository NewRepository() => NewRepository(_fixture.DbContextProvider);
+
+        private PeopleRepository NewRepository(IDbContextProvider provider)
         {
             _tenants.Setup(t => t.GetTenantByID(It.IsAny<string>()))
                     .Returns(new Tenant
@@ -34,7 +37,9 @@ namespace XUnitTest.Integration
                         DbConnectionString = "mongodb://x",
                         JwtTokenParameters = new JwtTokenParameters { IssueDate = DateTime.UtcNow, PrivateCertificatePassword = "p" }
                     });
-            return new PeopleRepository(_fixture.DbContextProvider, _tenants.Object, _projectRepo.Object);
+            var secret = new Mock<IBlocksSecret>();
+            secret.SetupGet(s => s.DatabaseConnectionString).Returns("mongodb://localhost:27017");
+            return new PeopleRepository(provider, _tenants.Object, _projectRepo.Object, secret.Object);
         }
 
         private Task InsertPeopleAsync(params ProjectPeople[] people)
@@ -281,6 +286,36 @@ namespace XUnitTest.Integration
         {
             using var _ = new IntegrationContext("ctx-" + Guid.NewGuid().ToString("N"));
             (await NewRepository().IsOwner("u1", new List<string>())).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ProjectPeoples_IsReadFromTheRootDb_WhenImpersonating()
+        {
+            // Every request made from inside a project is impersonated, so BlocksContext.TenantId
+            // is the project's own tenant and the bare IDbContextProvider.GetCollection resolves
+            // to that project's database. ProjectPeoples is never written there -- ProjectRepository
+            // pins all of its writes to the root database -- so these reads came back empty, and
+            // because ProjectAccessService decides ownership from exactly these rows, the owner of
+            // a project was refused as a non-member of it: Project/Create and Project/Disable both
+            // answered "Only the project owner can do this" with rows=0; ownerRows=0.
+            var suffix = Guid.NewGuid().ToString("N");
+            var tenant = "t-" + suffix;
+            var user = "u-" + suffix;
+
+            var provider = new SplitDatabaseContextProvider(_fixture.Client, _fixture.Database, "tenantdb_" + suffix);
+            using var _ = new BlocksTestContext(tenantId: tenant, userId: user, impersonated: true,
+                                                originalTenantId: "root-" + suffix);
+            var repo = NewRepository(provider);
+
+            // Written the way provisioning writes it: through the root database, not through the
+            // repository under test.
+            await InsertPeopleAsync(Person(user, tenant, "own@x.com", creator: true));
+
+            (await repo.GetProjectPeoplesAsync(user, new List<string> { tenant })).Should().HaveCount(1);
+            (await repo.IsOwner(user, new List<string> { tenant })).Should().BeTrue();
+            (await repo.GetProjectPeopleByTenantIdAndUserIdAsync(tenant, user)).Should().NotBeNull();
+
+            provider.Drop();
         }
     }
 }

--- a/server/XUnitTest/Integration/ProjectRepositoryTests.cs
+++ b/server/XUnitTest/Integration/ProjectRepositoryTests.cs
@@ -793,41 +793,6 @@ namespace XUnitTest.Integration
             provider.Drop();
         }
 
-        /// <summary>
-        /// Resolves BlocksRootDb to the fixture's database and every tenant-scoped request to a
-        /// separate one, so a repository reaching for the wrong handle reads an empty collection.
-        /// </summary>
-        private sealed class SplitDatabaseContextProvider : IDbContextProvider
-        {
-            private readonly IMongoClient _client;
-            private readonly IMongoDatabase _rootDatabase;
-            private readonly IMongoDatabase _tenantDatabase;
-            private readonly string _tenantDatabaseName;
-
-            public SplitDatabaseContextProvider(IMongoClient client, IMongoDatabase rootDatabase, string tenantDatabaseName)
-            {
-                _client = client;
-                _rootDatabase = rootDatabase;
-                _tenantDatabaseName = tenantDatabaseName;
-                _tenantDatabase = client.GetDatabase(tenantDatabaseName);
-            }
-
-            public void Drop() => _client.DropDatabase(_tenantDatabaseName);
-
-            public IMongoDatabase GetDatabase(string tenantId) => _tenantDatabase;
-
-            public IMongoDatabase GetDatabase() => _tenantDatabase;
-
-            public IMongoDatabase GetDatabase(string connectionString, string databaseName, bool isCacheRefreshed = false) =>
-                databaseName == "BlocksRootDb" ? _rootDatabase : _tenantDatabase;
-
-            public IMongoCollection<T> GetCollection<T>(string collectionName) =>
-                _tenantDatabase.GetCollection<T>(collectionName);
-
-            public IMongoCollection<T> GetCollection<T>(string tenantId, string collectionName) =>
-                _tenantDatabase.GetCollection<T>(collectionName);
-        }
-
         [Fact]
         public async Task GetAllByLastModifiedDateAsync_GroupsSelfProjects()
         {

--- a/server/XUnitTest/Integration/SplitDatabaseContextProvider.cs
+++ b/server/XUnitTest/Integration/SplitDatabaseContextProvider.cs
@@ -1,0 +1,48 @@
+using Blocks.Genesis;
+using DomainService.Shared;
+using MongoDB.Driver;
+
+namespace XUnitTest.Integration
+{
+    /// <summary>
+    /// Resolves the root database to the fixture's database and every tenant-scoped request to a
+    /// separate one, so a repository reaching for the wrong handle reads an empty collection.
+    /// </summary>
+    /// <remarks>
+    /// The shared fixture cannot stand in for this: its provider resolves the root database,
+    /// every tenant database and every bare <c>GetCollection</c> call to one throwaway database,
+    /// so the two handles are indistinguishable there. Whether a repository reads
+    /// <c>ProjectPeoples</c> from the database it was written to is only visible through a
+    /// provider that keeps them apart.
+    /// </remarks>
+    internal sealed class SplitDatabaseContextProvider : IDbContextProvider
+    {
+        private readonly IMongoClient _client;
+        private readonly IMongoDatabase _rootDatabase;
+        private readonly IMongoDatabase _tenantDatabase;
+        private readonly string _tenantDatabaseName;
+
+        public SplitDatabaseContextProvider(IMongoClient client, IMongoDatabase rootDatabase, string tenantDatabaseName)
+        {
+            _client = client;
+            _rootDatabase = rootDatabase;
+            _tenantDatabaseName = tenantDatabaseName;
+            _tenantDatabase = client.GetDatabase(tenantDatabaseName);
+        }
+
+        public void Drop() => _client.DropDatabase(_tenantDatabaseName);
+
+        public IMongoDatabase GetDatabase(string tenantId) => _tenantDatabase;
+
+        public IMongoDatabase GetDatabase() => _tenantDatabase;
+
+        public IMongoDatabase GetDatabase(string connectionString, string databaseName, bool isCacheRefreshed = false) =>
+            databaseName == IdentifierConstants.RootDatabaseName ? _rootDatabase : _tenantDatabase;
+
+        public IMongoCollection<T> GetCollection<T>(string collectionName) =>
+            _tenantDatabase.GetCollection<T>(collectionName);
+
+        public IMongoCollection<T> GetCollection<T>(string tenantId, string collectionName) =>
+            _tenantDatabase.GetCollection<T>(collectionName);
+    }
+}

--- a/server/XUnitTest/Services/ProjectManagementServiceTests.cs
+++ b/server/XUnitTest/Services/ProjectManagementServiceTests.cs
@@ -83,6 +83,65 @@ namespace XUnitTest.Services
         }
 
         [Fact]
+        public async Task SaveProjectAsync_NewGroup_RecordsTheCreatorBeforeQueueingTheProject()
+        {
+            // Provisioning is asynchronous, so the creator row used to be written only once the
+            // worker picked the project up. Until it did, the group had environments and no
+            // owner, and every [ProjectPolicy(OwnerOnly)] endpoint refused the person who had
+            // just created it -- adding an environment and deleting the project among them.
+            using var _ = new BlocksTestContext(userId: "creator-1", userName: "creator@blocks.com");
+
+            var written = new List<ProjectPeople>();
+            _repo.Setup(r => r.InsertPeopleAsync(It.IsAny<ProjectPeople>()))
+                 .Callback<ProjectPeople>(written.Add)
+                 .Returns(Task.CompletedTask);
+
+            var request = new CreateProjectRequest
+            {
+                Name = "Proj",
+                applicationContexts = new List<ApplicationContext>
+                {
+                    new() { Environment = "dev", Domain = "https://dev.example.com" },
+                    new() { Environment = "prod", Domain = "https://example.com" }
+                }
+            };
+
+            await Service().SaveProjectAsync(request);
+
+            // One per environment, so ownership survives any single environment being disabled.
+            written.Should().HaveCount(2);
+            written.Should().OnlyContain(row => row.IsCreator
+                                                && row.UserId == "creator-1"
+                                                && row.Email == "creator@blocks.com"
+                                                && row.IsInvitationConfirmed);
+            written.Select(row => row.TenantId).Should().OnlyHaveUniqueItems();
+        }
+
+        [Fact]
+        public async Task SaveProjectAsync_ExistingGroup_DoesNotStampTheCallerAsOwner()
+        {
+            // Appending an environment must leave ownership where it is. Stamping the caller
+            // here would hand the whole group to anyone who could add an environment to it.
+            using var _ = new BlocksTestContext(userId: "not-the-owner");
+            _repo.Setup(r => r.GetTenantAssetByGroupIdAsync("existing-group"))
+                 .ReturnsAsync(new TenantAsset { Resources = new List<Resource>() });
+
+            var request = new CreateProjectRequest
+            {
+                Name = "Proj",
+                TenantGroupId = "existing-group",
+                applicationContexts = new List<ApplicationContext>
+                {
+                    new() { Environment = "test", Domain = "https://test.example.com" }
+                }
+            };
+
+            await Service().SaveProjectAsync(request);
+
+            _repo.Verify(r => r.InsertPeopleAsync(It.IsAny<ProjectPeople>()), Times.Never);
+        }
+
+        [Fact]
         public async Task SaveProjectAsync_ExistingGroup_LoadsAssetsInsteadOfCreating()
         {
             using var _ = new BlocksTestContext();
@@ -1212,6 +1271,23 @@ namespace XUnitTest.Services
             _repo.Verify(r => r.CreateDefaultConfigurationAsync(It.IsAny<ProjectStatusTracer>(), project), Times.Once);
             // Public certificate download URL should be persisted on the project.
             project.JwtTokenParameters.PublicCertificatePath.Should().Be("https://download/cert");
+        }
+
+        [Fact]
+        public async Task ConfigureProjectAsync_DoesNotWriteASecondCreatorRow_WhenTheEnvironmentAlreadyHasAnOwner()
+        {
+            // The API now records ownership of a brand-new group before queueing it, so the
+            // worker arrives at an environment that already has a creator row. The tracer flag
+            // does not cover this -- it is a fresh tracer -- and neither does it cover a resumed
+            // run that wrote the row and crashed before the flag was saved. Two creator rows for
+            // one person on one tenant is what both used to produce.
+            using var _ = new BlocksTestContext();
+            SetupCertificatePipeline();
+            _repo.Setup(r => r.GetOwnerUserIdAsync("t1")).ReturnsAsync("creator-1");
+
+            await Service().ConfigureProjectAsync(NewTenantForConfigure());
+
+            _repo.Verify(r => r.InsertPeopleAsync(It.IsAny<ProjectPeople>()), Times.Never);
         }
 
         [Fact]

--- a/server/XUnitTest/Services/ProjectPolicyFilterTests.cs
+++ b/server/XUnitTest/Services/ProjectPolicyFilterTests.cs
@@ -1,0 +1,247 @@
+using System.Reflection;
+using DomainService.Access;
+using DomainService.Access.Services;
+
+using DomainService.Projects;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using XUnitTest.TestSupport;
+
+namespace XUnitTest.Services
+{
+    /// <summary>
+    /// How <see cref="ProjectPolicyFilter"/> decides which project a call is about. The
+    /// authorization verdict itself is the easy half; picking the wrong project to ask about is
+    /// what actually locked owners out of their own projects.
+    /// </summary>
+    public class ProjectPolicyFilterTests
+    {
+        private readonly Mock<IProjectAccessService> _access = new();
+
+        /// <summary>
+        /// Every endpoint on this stand-in mirrors the binding shape of a real one — that shape is
+        /// the whole input to the resolution being tested.
+        /// </summary>
+        private sealed class StubController : ControllerBase
+        {
+            [ProjectPolicy(OwnerOnly = true)]
+            public void Create(CreateProjectRequest request) { }
+
+            [ProjectPolicy(OwnerOnly = true)]
+            public void Disable(DisableProjectRequest request) { }
+
+            [ProjectPolicy("environments::view")]
+            public void GetMigrationStatus(string tenantGroupId) { }
+
+            public void Unguarded(CreateProjectRequest request) { }
+        }
+
+        [Fact]
+        public async Task Create_WithNoGroup_IsNotAuthorizedAgainstTheCallersCurrentProject()
+        {
+            // The regression this exists for: the create-project wizard posts no TenantGroupId,
+            // because the project does not exist yet. Resolution fell through to the tenant in
+            // the caller's token -- whichever project they last opened -- and OwnerOnly then
+            // refused them the creation of their own project ("Only the project owner can do
+            // this", rows=0). A blank group has to mean "no project", not "this project".
+            using var _ = new BlocksTestContext(tenantId: "DEVm5r5u3bv", impersonated: true);
+
+            var context = ContextFor(nameof(StubController.Create),
+                new Dictionary<string, object?> { ["request"] = new CreateProjectRequest { TenantGroupId = null } });
+
+            var ran = await RunAsync(context);
+
+            ran.Should().BeTrue("a brand-new project belongs to nobody yet, so there is nothing to authorize");
+            context.Result.Should().BeNull();
+            _access.Verify(a => a.ResolveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            _access.Verify(a => a.ResolveGroupOfProjectAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Create_WithAGroup_IsAuthorizedAgainstThatGroup()
+        {
+            // The same endpoint appends an environment when a group IS named, and that is
+            // owner-only for real. Skipping the check on a blank group must not skip it here.
+            using var _ = new BlocksTestContext(tenantId: "DEVother", impersonated: true);
+            Resolves("grp-1", isOwner: false, isMember: true);
+
+            var context = ContextFor(nameof(StubController.Create),
+                new Dictionary<string, object?> { ["request"] = new CreateProjectRequest { TenantGroupId = "grp-1" } });
+
+            var ran = await RunAsync(context);
+
+            ran.Should().BeFalse();
+            Denial(context).Should().Contain("Only the project owner");
+        }
+
+        [Fact]
+        public async Task Create_WithAGroupTheCallerOwns_Runs()
+        {
+            using var _ = new BlocksTestContext(tenantId: "DEVgrp1", impersonated: true);
+            Resolves("grp-1", isOwner: true, isMember: true);
+
+            var context = ContextFor(nameof(StubController.Create),
+                new Dictionary<string, object?> { ["request"] = new CreateProjectRequest { TenantGroupId = "grp-1" } });
+
+            (await RunAsync(context)).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Disable_WithAnEmptyRequest_FallsBackToTheProjectTheCallerIsIn()
+        {
+            // Project/Disable names no project at all: its request object has no fields, and the
+            // project to disable is the impersonated tenant. The fallback exists for this, and
+            // narrowing it must not take this case with it.
+            using var _ = new BlocksTestContext(tenantId: "DEVgrp1", impersonated: true);
+            _access.Setup(a => a.ResolveGroupOfProjectAsync("DEVgrp1")).ReturnsAsync("grp-1");
+            Resolves("grp-1", isOwner: true, isMember: true);
+
+            var context = ContextFor(nameof(StubController.Disable),
+                new Dictionary<string, object?> { ["request"] = new DisableProjectRequest() });
+
+            (await RunAsync(context)).Should().BeTrue();
+            _access.Verify(a => a.ResolveGroupOfProjectAsync("DEVgrp1"), Times.Once);
+        }
+
+        [Fact]
+        public async Task Disable_WhenTheCallerIsNotTheOwner_IsRefused()
+        {
+            using var _ = new BlocksTestContext(tenantId: "DEVgrp1", impersonated: true);
+            _access.Setup(a => a.ResolveGroupOfProjectAsync("DEVgrp1")).ReturnsAsync("grp-1");
+            Resolves("grp-1", isOwner: false, isMember: true);
+
+            var context = ContextFor(nameof(StubController.Disable),
+                new Dictionary<string, object?> { ["request"] = new DisableProjectRequest() });
+
+            (await RunAsync(context)).Should().BeFalse();
+            Denial(context).Should().Contain("Only the project owner");
+        }
+
+        [Fact]
+        public async Task AnAbsentQueryStringArgument_CountsAsNamingNoProject()
+        {
+            // [FromQuery] string binds to null when it is missing, so the argument's presence --
+            // not its value -- is what says the endpoint is self-scoping. The endpoint rejects the
+            // empty value itself, which is a clearer answer than an authorization error.
+            using var _ = new BlocksTestContext(tenantId: "DEVgrp1", impersonated: true);
+
+            var context = ContextFor(nameof(StubController.GetMigrationStatus),
+                new Dictionary<string, object?> { ["tenantGroupId"] = null });
+
+            (await RunAsync(context)).Should().BeTrue();
+            _access.Verify(a => a.ResolveGroupOfProjectAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AQueryStringArgument_ScopesTheCheckToItsGroup()
+        {
+            using var _ = new BlocksTestContext(tenantId: "DEVother", impersonated: true);
+            Resolves("grp-1", isOwner: false, isMember: true, policies: ["environments::view"]);
+
+            var context = ContextFor(nameof(StubController.GetMigrationStatus),
+                new Dictionary<string, object?> { ["tenantGroupId"] = "grp-1" });
+
+            (await RunAsync(context)).Should().BeTrue();
+            _access.Verify(a => a.ResolveAsync("grp-1", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AGrantedMenuActionTheCallerDoesNotHold_IsRefused()
+        {
+            using var _ = new BlocksTestContext(tenantId: "DEVother", impersonated: true);
+            Resolves("grp-1", isOwner: false, isMember: true, policies: ["people::view"]);
+
+            var context = ContextFor(nameof(StubController.GetMigrationStatus),
+                new Dictionary<string, object?> { ["tenantGroupId"] = "grp-1" });
+
+            (await RunAsync(context)).Should().BeFalse();
+            Denial(context).Should().Contain("not been given access");
+        }
+
+        [Fact]
+        public async Task TheOwner_PassesEveryGuardedEndpointWithoutHoldingAnyGrant()
+        {
+            // "The owner can do anything" is load-bearing: owners hold no AccessPolicies at all
+            // (SaveAccessPolicy refuses to write any onto them), so an owner who had to satisfy
+            // the policy string would satisfy none of them.
+            using var _ = new BlocksTestContext(tenantId: "DEVother", impersonated: true);
+            Resolves("grp-1", isOwner: true, isMember: true, policies: []);
+
+            var context = ContextFor(nameof(StubController.GetMigrationStatus),
+                new Dictionary<string, object?> { ["tenantGroupId"] = "grp-1" });
+
+            (await RunAsync(context)).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task AnEndpointWithoutTheAttribute_IsNotProjectScoped()
+        {
+            using var _ = new BlocksTestContext(tenantId: "DEVgrp1", impersonated: true);
+
+            var context = ContextFor(nameof(StubController.Unguarded),
+                new Dictionary<string, object?> { ["request"] = new CreateProjectRequest { TenantGroupId = "grp-1" } });
+
+            (await RunAsync(context)).Should().BeTrue();
+            _access.Verify(a => a.ResolveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        // ── Harness ─────────────────────────────────────────────────────────────
+
+        private void Resolves(string groupId, bool isOwner, bool isMember, string[]? policies = null)
+        {
+            _access.Setup(a => a.ResolveAsync(groupId, It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(new ProjectAccessContext
+                   {
+                       ProjectGroupId = groupId,
+                       IsOwner = isOwner,
+                       IsMember = isMember,
+                       Policies = [.. policies ?? []],
+                   });
+        }
+
+        /// <summary>Whether the action itself was reached, which is the only pass signal.</summary>
+        private async Task<bool> RunAsync(ActionExecutingContext context)
+        {
+            var ran = false;
+
+            await new ProjectPolicyFilter(_access.Object).OnActionExecutionAsync(context, () =>
+            {
+                ran = true;
+                return Task.FromResult(new ActionExecutedContext(context, context.Filters, context.Controller));
+            });
+
+            return ran;
+        }
+
+        private static ActionExecutingContext ContextFor(string actionName, Dictionary<string, object?> arguments)
+        {
+            var method = typeof(StubController).GetMethod(actionName)!;
+
+            var actionContext = new ActionContext(
+                new DefaultHttpContext(),
+                new RouteData(),
+                new ControllerActionDescriptor { MethodInfo = method, ActionName = actionName },
+                new ModelStateDictionary());
+
+            return new ActionExecutingContext(actionContext, [], arguments, new StubController());
+        }
+
+        private static string Denial(ActionExecutingContext context)
+        {
+            var result = context.Result.Should().BeOfType<ObjectResult>().Subject;
+            result.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+            var response = result.Value.Should().BeOfType<Blocks.Genesis.BaseResponse>().Subject;
+            response.IsSuccess.Should().BeFalse();
+
+            return response.Errors!["own_project"];
+        }
+    }
+}


### PR DESCRIPTION
- Updated @seliseblocks/genesis-os to version 4.3.1 and @seliseblocks/mailcraft to version 0.2.9 in package.json and package-lock.json.
- Enhanced ProjectPolicyFilter to better handle project resolution logic, ensuring that requests without a specified group are treated as unscoped.
- Refactored ProjectAccessService to streamline ownership checks and ensure correct handling of project creator rows.
- Introduced SplitDatabaseContextProvider for better database context management during tests.
- Added comprehensive unit tests for ProjectPolicyFilter to validate authorization logic across various scenarios.