### PR TITLE
fix(client): restore the lockfile entries npm 10 requires

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3689,6 +3689,24 @@
         }
       }
     },
+    "node_modules/@seliseblocks/genesis-os/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@seliseblocks/genesis-os/node_modules/cmdk": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
@@ -3723,6 +3741,14 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/@seliseblocks/genesis-os/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@seliseblocks/genesis-os/node_modules/lucide-react": {
       "version": "1.33.0",
@@ -6708,6 +6734,24 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.2",


### PR DESCRIPTION
The cherry-pick onto stg regenerated client/package-lock.json with the local npm 11, which prunes optional peer dependencies that npm 10 still records. That dropped ajv, json-schema-traverse and fast-uri from under @seliseblocks/genesis-os, so `npm ci` in the Docker build (npm 10.9.8 on node:22-alpine) rejected the lockfile as out of sync with package.json.

Regenerated from stg's pre-cherry-pick lockfile using npm 10.9.8, so the only dependency change it carries is the genesis-os 4.3.1 bump.